### PR TITLE
fix: HTML tags not work.

### DIFF
--- a/lua/nvim-surround/html.lua
+++ b/lua/nvim-surround/html.lua
@@ -26,7 +26,7 @@ M.get_tag = function(include_brackets)
         open = "<" .. open .. ">"
         close = "</" .. close .. ">"
     end
-    local tag = { open, close }
+    local tag = { { open }, { close } }
 
     return tag
     --[[ TODO: Figure out how to make vim.ui.input blocking


### PR DESCRIPTION
I get an error when surround a html tag.

```
E5108: Error executing lua .../packer/start/nvim-surround/lua/nvim-surround/buffer.lua:154: attempt to concatenate a nil value
```

After some tests, it was found that the format of the return value of `get_tag` was wrong.

So, I simply fixed it.