### PR TITLE
tests: Use a consistent `shiftwidth` in tests

### DIFF
--- a/tests/surround_spec.lua
+++ b/tests/surround_spec.lua
@@ -30,6 +30,7 @@ describe("nvim-surround", function()
     vim.cmd("set filetype=lua")
     before_each(function()
         cursor({ 1, 1 })
+        vim.o.shiftwidth = 4
         -- Setup default keybinds (can be overwritten with subsequent calls)
         require("nvim-surround").setup({})
     end)


### PR DESCRIPTION
When running the tests using `<Plug>PlenaryTestFile` the `shiftwidth` option was inherited from the user's config. For users that modified `shiftwidth` in their configuration the tests were failing. One of the tests ("nvim-surround can visual-line surround") indented a line while doing a surround but due to a different `shiftwidth`, the size of the indent did not match the expected 4 spaces.

![image](https://user-images.githubusercontent.com/889383/179346413-da884d71-9f1f-48bb-98cb-a59b73eb7061.png)

This change makes all tests pass:

![image](https://user-images.githubusercontent.com/889383/179346468-fceb9d54-806b-4ccf-ab58-d682c11691b7.png)


It is possible that other indent-related options should also be set so the tests behave consistently. `expandtab` comes to my mind.