### PR TITLE
fix: Add final HTML tag angle bracket only once

### DIFF
--- a/lua/nvim-surround/html.lua
+++ b/lua/nvim-surround/html.lua
@@ -18,7 +18,7 @@ M.get_tag = function(include_brackets)
         return nil
     end
     local element = input:match("^<?([%w-]+)")
-    local attributes = input:match(" +(.+)>?$")
+    local attributes = input:match(" +([^>]+)>?$")
     if not element then
         return nil
     end

--- a/tests/surround_spec.lua
+++ b/tests/surround_spec.lua
@@ -253,6 +253,24 @@ describe("nvim-surround", function()
         check_lines({ "so|left|func_name(me) te|right|xt" })
     end)
 
+    for _, tag in ipairs({ "div", "<div>", "<div" }) do
+        it("can surround with an HTML tag " .. tag, function()
+            set_lines({ "some text" })
+            cursor({ 1, 3 })
+            insert_surround("s", "t" .. tag .. cr)
+            check_lines({ "<div>some text</div>" })
+        end)
+    end
+
+    for _, tag in ipairs({ 'div class="test"', '<div class="test"', '<div class="test">' }) do
+        it("can surround with an HTML tag with attributes " .. tag, function()
+            set_lines({ "some text" })
+            cursor({ 1, 3 })
+            insert_surround("s", "t" .. tag .. cr)
+            check_lines({ '<div class="test">some text</div>' })
+        end)
+    end
+
     it("can dot-repeat user-inputted delimiters", function()
         set_lines({ "here", "are", "some", "lines" })
         insert_surround("iw", "f" .. "func_name" .. cr)


### PR DESCRIPTION
Hey! First of all, thanks for this great plugin :tada: I appreciate that I can hack away at surrounding objects using Lua and not Vimscript :sweat_smile:

As a contributor, I appreciate that this plugin has tests which I could easily extend to add a failing test case for the bug I found. The Lua code seems to also be well-structured and I could easily find the place I had to change to fix the bug.

---

I noticed a bug when surrounding with `t<div class="test">` - the final angle bracket was inserted twice. The final output was:

```txt
<div class="test">>some text</div>
```

instead of 

```diff
-<div class="test">>some text</div>
+<div class="test">some text</div>
```

I decided to add tests for surrounding with HTML tags (one of which was failing because of this bug), and then fix it in another commit.

The problem seems to be due to `(.*)` (in the `(.*)>?` regular expression) eagerly including the final `>` of the input **inside** of the `.*` matching group. By using `[^>]` for the attributes instead of `.*`, the final angle bracket is correctly matched by `>?`.

## Tests result

<details>

```sh
10:36 $ nvim --headless -c "PlenaryBustedDirector tests"
Starting...Scheduling: tests/surround_spec.lua

========================================
Testing:        /home/voreny/.local/share/nvim/site/pack/packer/start/nvim-surround/tests/surround_spec.lua
Success ||      nvim-surround can be setup without a table
Success ||      nvim-surround can surround text-objects
Success ||      nvim-surround can delete surrounding quotes/parens
Success ||      nvim-surround can change surrounding delimiters
Success ||      nvim-surround can delete quotes using aliases
Success ||      nvim-surround can modify surrounds that appear at 1, 1
Success ||      nvim-surround can dot-repeat insertions
Success ||      nvim-surround can dot-repeat deletions
Success ||      nvim-surround can dot-repeat changes
Success ||      nvim-surround can dot-repeat deletions (aliased)
Success ||      nvim-surround can dot-repeat changes (aliased)
Success ||      nvim-surround can do the demonstration
Fail    ||      nvim-surround can visual-line surround
            .../pack/packer/start/nvim-surround/tests/surround_spec.lua:26: Expected objects to be the same.
            Passed in:
            (table: 0x7f4cc947a198) {
              [1] = '{'
             *[2] = '  'hello','
              [3] = '}'
              [4] = ''hello','
              [5] = ''hello',' }
            Expected:
            (table: 0x7f4cc9479f80) {
              [1] = '{'
             *[2] = '    'hello','
              [3] = '}'
              [4] = ''hello','
              [5] = ''hello',' }

            stack traceback:
                .../pack/packer/start/nvim-surround/tests/surround_spec.lua:26: in function 'check_lines'
                .../pack/packer/start/nvim-surround/tests/surround_spec.lua:197: in function <.../pack/packer/start/nvim-surround/tests/surround_spec.lua:189>

Success ||      nvim-surround can deal with different whitespace characters
Success ||      nvim-surround can insert user-inputted delimiters
Success ||      nvim-surround can surround with an HTML tag div
Success ||      nvim-surround can surround with an HTML tag <div>
Success ||      nvim-surround can surround with an HTML tag <div
Success ||      nvim-surround can surround with an HTML tag with attributes div class="test"
Success ||      nvim-surround can surround with an HTML tag with attributes <div class="test"
Success ||      nvim-surround can surround with an HTML tag with attributes <div class="test">
Success ||      nvim-surround can dot-repeat user-inputted delimiters
Success ||      nvim-surround can jump to the deletion properly
Success ||      nvim-surround can dot-repeat jumps properly
Success ||      nvim-surround can handle quotes smartly
Success ||      nvim-surround can delete close/empty pairs
Success ||      nvim-surround can disable default delimiters
Success ||      nvim-surround can modify aliases

Success:        27
Failed :        1
Errors :        0
========================================
```

</details>

The one failing test is due to `vim.o.shiftwidth = 2` in my `init.lua`. It is fixed by #81 

## Minor suggestions

While contributing, I noticed that:

1. There is not formatter configured for this project. By default, [StyLua](https://github.com/JohnnyMorganz/StyLua) (which I run on save) was formatting the code in a different way than it is formatted at the moment. This was mildly annoying since I had to `:noa w` or disable the auto-formatting on save. Maybe we should have a formatter (e.g. stylua) configured for this project (and maybe also verify it in CI)?
2. The tests are not run in GitHub Actions

both of these seem like easy chores that would make it more convenient for other contributors.