### PR TITLE
ci: enable GitHub actions for stylua, luacheck and tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup luarocks
+        shell: bash
+        run: |
+          sudo apt install -y luarocks
+          sudo luarocks install luacheck
+
+      - name: Run luacheck
+        run: luacheck lua/ tests/
+
+
+  stylua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: JohnnyMorganz/stylua-action@1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --color always --check lua/ tests/
+
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: nightly
+
+      - name: Install plenary
+        run: |
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+          ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
+
+      - name: Run tests
+        run: nvim --headless --noplugin -c 'packadd plenary.nvim' -c "PlenaryBustedDirectory tests/"

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,16 @@
+std = luajit
+codes = true
+max_line_length = 120
+max_comment_line_length = false
+
+read_globals = {
+  "vim"
+}
+
+globals = {
+  vim = {
+    fields = {
+      g
+    }
+  }
+}

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -74,7 +74,7 @@ M.default_opts = {
 }
 
 -- Stores the global user-set options for the plugin.
-M.user_opts = nil
+M.user_opts = {}
 
 -- Returns the buffer-local options for the plugin.
 ---@return options @The buffer-local options.


### PR DESCRIPTION
You can see an example CI run here: https://github.com/smjonas/nvim-surround/pull/1

Currently the tests are failing (locally as well), but that should be fixed separately.