### PR TITLE
fix: Error on invalid key, bad indent in insert_surround()

### DIFF
--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -56,12 +56,8 @@ M.insert_surround = function(line_mode)
     -- Indent the cursor to the correct level, if added line-wise
     if line_mode then
         local lnum = buffer.get_curpos()[1]
-        if vim.bo.expandtab then
-            buffer.insert_lines({ lnum, 1 }, { (" "):rep(vim.fn.indent(lnum + 1) + vim.bo.shiftwidth) })
-        else
-            local num_tabs = vim.fn.indent(lnum + 1) / vim.bo.shiftwidth
-            buffer.insert_lines({ lnum, 1 }, { ("	"):rep(num_tabs + 1) })
-        end
+
+        vim.cmd(lnum .. "left " .. vim.fn.indent(lnum + 1) + vim.fn.shiftwidth())
         buffer.set_curpos({ lnum, #buffer.get_line(lnum) + 1 })
     end
 end

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -38,6 +38,9 @@ end
 M.insert_surround = function(line_mode)
     local char = utils.get_char()
     local delimiters = utils.get_delimiters(char)
+    if not delimiters then
+        return
+    end
     local curpos = buffer.get_curpos()
 
     -- Add new lines if the addition is done line-wise


### PR DESCRIPTION
Firstly, this fixes the insert mode surround feature causing a `…/nvim-surround/lua/nvim-surround/init.lua:49: attempt to index local 'delimiters' (a nil value)` Lua error when pressing a key that doesn't map to any delimiter.

Secondly, this makes the indentation of the inner line in multi-line mode (`<c-g>S` by default) consistent with native auto-indent. Before this patch, if `shiftwidth` was `0` the inner line would have the same indent as the lines next to it.

This plugin would also falsely assume all tabs have a width equal to `shiftwidth`. Tab width is always defined by `tabstop` (unless `vartabstop` is set) and `shiftwidth` doesn't even have to be a multiple of `tabstop`, regardless of whether `expandtab` is set. Any configuration with `noexpandtab` and a `shiftwidth` that isn't identical to `tabstop` (or `0`, which has the same meaning) or at least a multiple of `tabstop` is, of course, awful, but that doesn't mean `nvim-surround` can't do what native indent behaviour does.

`vartabstop` is even more cursed, but if there's anyone who actually uses both it and this plugin I'm sure they'll be pleased to see this fix. :stuck_out_tongue: