### PR TITLE
refactor!: Abstract text-objects code into separate file.

### DIFF
--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -134,6 +134,14 @@ M.comes_before = function(pos1, pos2)
     return pos1[1] < pos2[1] or pos1[1] == pos2[1] and pos1[2] <= pos2[2]
 end
 
+-- Returns whether a position is contained within a pair of selections, inclusive.
+---@param pos integer[] The given position.
+---@selection selections selections The given selections
+---@return boolean @Whether the position is contained within the selections.
+M.is_inside = function(pos, selections)
+    return M.comes_before(selections.left.first_pos, pos) and M.comes_before(pos, selections.right.last_pos)
+end
+
 -- Gets a selection of text from the buffer.
 ---@param selection selection The selection of text to be retrieved.
 ---@return string[] @The text from the buffer.

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -357,7 +357,8 @@ end
 ---@return function? @The function to get the delimiters to be added.
 M.get_add = function(char)
     char = require("nvim-surround.utils").get_alias(char)
-    return M.get_opts().delimiters[char] and M.get_opts().delimiters[char].add
+    local key = M.get_opts().delimiters[char] or M.get_opts().delimiters.invalid_key_behavior
+    return key.add
 end
 
 -- Returns the delete key for the surround associated with a given character, if one exists.
@@ -365,7 +366,8 @@ end
 ---@return function? @The function to get the selections to be deleted.
 M.get_delete = function(char)
     char = require("nvim-surround.utils").get_alias(char)
-    return M.get_opts().delimiters[char] and M.get_opts().delimiters[char].delete
+    local key = M.get_opts().delimiters[char] or M.get_opts().delimiters.invalid_key_behavior
+    return key.delete
 end
 
 -- Returns the change key for the surround associated with a given character, if one exists.
@@ -373,7 +375,8 @@ end
 ---@return { target: function, replacement: function? }? @A table holding the target/replacment functions.
 M.get_change = function(char)
     char = require("nvim-surround.utils").get_alias(char)
-    return M.get_opts().delimiters[char] and M.get_opts().delimiters[char].change
+    local key = M.get_opts().delimiters[char] or M.get_opts().delimiters.invalid_key_behavior
+    return key.change
 end
 
 -- Translates the user-provided configuration into the internal form.

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -24,7 +24,7 @@ M.default_opts = {
             end,
             change = {
                 target = function()
-                    return M.get_selections({ char = "(", pattern = "^(.)().-(.)()$" })
+                    return M.get_selections({ char = "(", pattern = "^(. ?)().-( ?.)()$" })
                 end,
             },
         },
@@ -52,7 +52,7 @@ M.default_opts = {
             end,
             change = {
                 target = function()
-                    return M.get_selections({ char = "{", pattern = "^(.)().-(.)()$" })
+                    return M.get_selections({ char = "{", pattern = "^(. ?)().-( ?.)()$" })
                 end,
             },
         },
@@ -80,7 +80,7 @@ M.default_opts = {
             end,
             change = {
                 target = function()
-                    return M.get_selections({ char = "<", pattern = "^(.)().-(.)()$" })
+                    return M.get_selections({ char = "<", pattern = "^(. ?)().-( ?.)()$" })
                 end,
             },
         },
@@ -108,7 +108,7 @@ M.default_opts = {
             end,
             change = {
                 target = function()
-                    return M.get_selections({ char = "[", pattern = "^(.)().-(.)()$" })
+                    return M.get_selections({ char = "[", pattern = "^(. ?)().-( ?.)()$" })
                 end,
             },
         },
@@ -327,8 +327,7 @@ M.get_selection = function(args)
     if args.pattern then
         return require("nvim-surround.patterns").get_selection(args.pattern)
     elseif args.textobject then
-        require("nvim-surround.buffer").set_operator_marks(args.textobject)
-        return require("nvim-surround.utils").get_user_selection(false)
+        return require("nvim-surround.textobjects").get_selection(args.textobject)
     end
 end
 

--- a/lua/nvim-surround/textobjects.lua
+++ b/lua/nvim-surround/textobjects.lua
@@ -2,27 +2,63 @@ local buffer = require("nvim-surround.buffer")
 
 local M = {}
 
+M.is_quote = function(char)
+    return char == "'" or char == '"' or char == "`"
+end
+
 -- Gets a selection based on the text-object for a given character, `a[char]`.
 ---@param char string The provided character.
 ---@return selection? @The selection that represents the text-object.
 M.get_selection = function(char)
+    -- Smart quotes feature; jump to the next quote if it is on the same line
+    local curpos = buffer.get_curpos()
+    if M.is_quote(char) and vim.fn.searchpos(char, "cnW")[1] == curpos[1] then
+        vim.fn.cursor(vim.fn.searchpos(char, "cnW"))
+    end
+
     buffer.set_operator_marks(char)
     -- Adjust the marks to reside on non-whitespace characters
     buffer.adjust_mark("[")
     buffer.adjust_mark("]")
 
     -- Get the row and column of the first and last characters of the selection
-    local first_position = buffer.get_mark("[")
-    local last_position = buffer.get_mark("]")
-    if not first_position or not last_position then
-        return nil
+    local selection = {
+        first_pos = buffer.get_mark("["),
+        last_pos = buffer.get_mark("]"),
+    }
+    -- If a selection is found surrounding the cursor or after it, then return
+    if selection.first_pos and selection.last_pos then
+        -- Restore the cursor position
+        buffer.set_curpos(curpos)
+        return selection
     end
 
-    local selection = {
-        first_pos = first_position,
-        last_pos = last_position,
+    -- Since no selection was found around/after the cursor, we look behind
+    if char == "t" then -- Handle special case with lookbehind for HTML tags (search for `>` instead of `t`)
+        vim.fn.searchpos(">", "bcW")
+    elseif M.is_quote(char) then -- Handle special case with lookbehind for quote characters (stay in current line)
+        if vim.fn.searchpos(char, "bncW")[1] == curpos[1] then
+            vim.fn.searchpos(char, "bcW")
+        end
+    else -- General case, jump to the character
+        vim.fn.searchpos(char, "bcW")
+    end
+
+    buffer.set_operator_marks(char)
+    -- Adjust the marks to reside on non-whitespace characters
+    buffer.adjust_mark("[")
+    buffer.adjust_mark("]")
+
+    -- Get the row and column of the first and last characters of the selection
+    selection = {
+        first_pos = buffer.get_mark("["),
+        last_pos = buffer.get_mark("]"),
     }
-    return selection
+
+    -- Restore the cursor position
+    buffer.set_curpos(curpos)
+    -- Return nil if either endpoint of the selection do not exist
+    return selection.first_pos and selection.last_pos and selection
 end
 
 return M

--- a/lua/nvim-surround/textobjects.lua
+++ b/lua/nvim-surround/textobjects.lua
@@ -2,9 +2,12 @@ local buffer = require("nvim-surround.buffer")
 
 local M = {}
 
-M.get_selection = function(textobject)
-    buffer.set_operator_marks(textobject)
-    -- Determine whether to use visual marks or operator marks
+-- Gets a selection based on the text-object for a given character, `a[char]`.
+---@param char string The provided character.
+---@return selection? @The selection that represents the text-object.
+M.get_selection = function(char)
+    buffer.set_operator_marks(char)
+    -- Adjust the marks to reside on non-whitespace characters
     buffer.adjust_mark("[")
     buffer.adjust_mark("]")
 
@@ -21,7 +24,5 @@ M.get_selection = function(textobject)
     }
     return selection
 end
-
-M.get_selections = function() end
 
 return M

--- a/lua/nvim-surround/textobjects.lua
+++ b/lua/nvim-surround/textobjects.lua
@@ -1,0 +1,27 @@
+local buffer = require("nvim-surround.buffer")
+
+local M = {}
+
+M.get_selection = function(textobject)
+    buffer.set_operator_marks(textobject)
+    -- Determine whether to use visual marks or operator marks
+    buffer.adjust_mark("[")
+    buffer.adjust_mark("]")
+
+    -- Get the row and column of the first and last characters of the selection
+    local first_position = buffer.get_mark("[")
+    local last_position = buffer.get_mark("]")
+    if not first_position or not last_position then
+        return nil
+    end
+
+    local selection = {
+        first_pos = first_position,
+        last_pos = last_position,
+    }
+    return selection
+end
+
+M.get_selections = function() end
+
+return M

--- a/lua/nvim-surround/utils.lua
+++ b/lua/nvim-surround/utils.lua
@@ -69,33 +69,6 @@ M.get_delimiters = function(char)
     return add and vim.deepcopy(add(char)) or config.get_opts().delimiters.invalid_key_behavior.add(char)
 end
 
--- Gets the coordinates of the start and end of a given selection.
----@return selection? @A table containing the start and end of the selection.
-M.get_user_selection = function(is_visual)
-    -- Determine whether to use visual marks or operator marks
-    local mark1, mark2
-    if is_visual then
-        mark1, mark2 = "<", ">"
-    else
-        mark1, mark2 = "[", "]"
-        buffer.adjust_mark("[")
-        buffer.adjust_mark("]")
-    end
-
-    -- Get the row and column of the first and last characters of the selection
-    local first_position = buffer.get_mark(mark1)
-    local last_position = buffer.get_mark(mark2)
-    if not first_position or not last_position then
-        return nil
-    end
-
-    local selection = {
-        first_pos = first_position,
-        last_pos = last_position,
-    }
-    return selection
-end
-
 -- Gets a selection that contains the left and right surrounding pair.
 ---@param char string A character representing what selection is to be found.
 ---@return selection? @The corresponding selection for the given character.

--- a/lua/nvim-surround/utils.lua
+++ b/lua/nvim-surround/utils.lua
@@ -1,7 +1,6 @@
 local buffer = require("nvim-surround.buffer")
 local config = require("nvim-surround.config")
 local patterns = require("nvim-surround.patterns")
-local textobjects = require("nvim-surround.textobjects")
 
 local M = {}
 

--- a/tests/surround_spec.lua
+++ b/tests/surround_spec.lua
@@ -30,7 +30,7 @@ end
 local check_lines = function(lines)
     assert.are.same(lines, vim.api.nvim_buf_get_lines(0, 0, -1, false))
 end
-
+-- TODO: Add test case for jumping to HTML tags, especially lookbehind (to test t/< case)
 describe("nvim-surround", function()
     before_each(function()
         cursor({ 1, 1 })


### PR DESCRIPTION
## Breaking Changes
Surround actions that involve opening delimiters like `cs<>` have slightly different behavior; it
will remove a space character if only one side has it, e.g. `cs<>` on
```
< hello world>
```
will yield
```
<hello world>
```