### PR TITLE
Compatibility issue with Lua5.1

### DIFF
--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -77,7 +77,7 @@ M.get_first_byte = function(pos)
         return pos
     end
     -- See https://en.wikipedia.org/wiki/UTF-8#Encoding
-    while byte >= 0B10000000 and byte < 0B11000000 do
+    while byte >= 0x80 and byte < 0xc0 do
         pos[2] = pos[2] - 1
         byte = string.byte(M.get_line(pos[1]):sub(pos[2], pos[2]))
     end
@@ -93,11 +93,11 @@ M.get_last_byte = function(pos)
         return pos
     end
     -- See https://en.wikipedia.org/wiki/UTF-8#Encoding
-    if byte >= 0B11110000 then
+    if byte >= 0xf0 then
         pos[2] = pos[2] + 3
-    elseif byte >= 0B11100000 then
+    elseif byte >= 0xe0 then
         pos[2] = pos[2] + 2
-    elseif byte >= 0B11000000 then
+    elseif byte >= 0xc0 then
         pos[2] = pos[2] + 1
     end
     return pos


### PR DESCRIPTION
Neovim on ARM is shipped with Lua5.1 instead of LuaJIT so this patch fix invalid binary number notation.

(related https://github.com/neovim/neovim/issues/19837)