### PR TITLE
fix: Handle special characters for `getchar`.

### DIFF
--- a/lua/nvim-surround/utils.lua
+++ b/lua/nvim-surround/utils.lua
@@ -12,7 +12,7 @@ M.NOOP = function() end
 M.get_char = function()
     local ret_val, char_num = pcall(vim.fn.getchar)
     -- Return nil if error (e.g. <C-c>) or for control characters
-    if not ret_val or char_num < 32 then
+    if not ret_val or type(char_num) ~= "number" or char_num < 32 then
         return nil
     end
     local char = vim.fn.nr2char(char_num)


### PR DESCRIPTION
`getchar` returns a string for special keys ([ref](https://neovim.io/doc/user/builtin.html#getchar())). so `ys` + e.g. arrow keys will give some error messages.