### PR TITLE
fix: <Plug>(nvim-surround-insert) mapping

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -571,7 +571,7 @@ end
 M.set_keymaps = function(buffer)
     -- Set up <Plug> keymaps
     M.set_keymap({
-        mode = "n",
+        mode = "i",
         lhs = "<Plug>(nvim-surround-insert)",
         rhs = require("nvim-surround").insert_surround,
         opts = {


### PR DESCRIPTION
# What

Fix the `<Plug>(Nvim-surround-insert)` mapping since the mainline version mapped it in normal mode.

# Test

Tested on my local setup and verify it worked.