### PR TITLE
make get_selection optionally accept list

### DIFF
--- a/lua/nvim-surround/treesitter.lua
+++ b/lua/nvim-surround/treesitter.lua
@@ -1,9 +1,19 @@
 local M = {}
 
--- Finds the nearest selection of a given Tree-sitter node type.
----@param type string The Tree-sitter node type to be retrieved.
+local function find_match(string, list_of_strings)
+    for _, element in ipairs(list_of_strings) do
+        if string == element then return true end
+    end
+    return false
+end
+
+-- Finds the nearest selection of a given Tree-sitter node type or types.
+---@param node_type string|string[] The Tree-sitter node types to be retrieved.
 ---@return selection? @The selection of the node.
-M.get_selection = function(type)
+M.get_selection = function(node_type)
+    if type(node_type) == "string" then
+        node_type = { node_type }
+    end
     local utils = require("nvim-surround.utils")
     local ok, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
     if not ok then
@@ -23,7 +33,7 @@ M.get_selection = function(type)
     while #stack > 0 do
         local cur = stack[#stack]
         -- If the current node's type matches the target type, process it
-        if cur:type() == type then
+        if find_match(cur:type(), node_type) then
             -- Add the current node to the stack
             nodes[#nodes + 1] = cur
             -- Compute the node's selection and add it to the list

--- a/lua/nvim-surround/treesitter.lua
+++ b/lua/nvim-surround/treesitter.lua
@@ -2,7 +2,9 @@ local M = {}
 
 local function find_match(string, list_of_strings)
     for _, element in ipairs(list_of_strings) do
-        if string == element then return true end
+        if string == element then
+            return true
+        end
     end
     return false
 end


### PR DESCRIPTION
I'm working primarily with the LaTeX parser, which for various reasons has multiple node types as possible targets for doing something like implementing `c`hange `s`urrounding `e`nvironment in Lua. Concretely, the text
```latex
\begin{SOMETHING}
% yadda yadda
\end{SOMETHING}
```
will be captured as either `generic_environment` or `math_environment` depending on the contents of `SOMETHING`. Anyway for this reason it would be nice to be able to use the `node` option to `get_selection` with multiple arguments; hence the change.