### PR TITLE
Add indentation when using line mode

### DIFF
--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -93,6 +93,10 @@ M.normal_surround = function(args, line_mode)
     buffer.insert_text(last_pos, args.delimiters[2])
     buffer.insert_text(first_pos, args.delimiters[1])
     buffer.reset_curpos(M.normal_curpos)
+
+    if line_mode and config.get_opts().indent_lines then
+        config.get_opts().indent_lines(first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
+    end
 end
 
 -- Add delimiters around a visual selection.


### PR DESCRIPTION
Fix #184 indentation when surrounding with line mode in normal mode.

Here, the second `"` should not be at col 0.
<img width="458" alt="Screenshot 2022-12-10 at 2 55 35 PM" src="https://user-images.githubusercontent.com/22773951/206873039-feb88d97-ab87-4ddf-93af-a88a56431cb1.png">
