### PR TITLE
Fix (line mode): Use line mode parameter when possible

### DIFF
--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -93,6 +93,10 @@ M.normal_surround = function(args, line_mode)
     buffer.insert_text(last_pos, args.delimiters[2])
     buffer.insert_text(first_pos, args.delimiters[1])
     buffer.reset_curpos(M.normal_curpos)
+
+    if line_mode and config.get_opts().indent_lines then
+        config.get_opts().indent_lines(first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
+    end
 end
 
 -- Add delimiters around a visual selection.

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -270,7 +270,7 @@ M.normal_callback = function(mode)
     M.normal_surround({
         delimiters = cache.normal.delimiters,
         selection = selection,
-    }, false)
+    }, cache.normal.line_mode)
 end
 
 M.delete_callback = function()


### PR DESCRIPTION
In normal callback, the call to `normal_surround` would always send false for `line_mode`.