### PR TITLE
feat: Support special keys for `surrounds` definition (#179)

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -227,14 +227,23 @@ M.default_opts = {
         },
         invalid_key_behavior = {
             add = function(char)
+                if char:byte() < 32 then
+                    return
+                end
                 return { { char }, { char } }
             end,
             find = function(char)
+                if char:byte() < 32 then
+                    return
+                end
                 return M.get_selection({
                     pattern = vim.pesc(char) .. ".-" .. vim.pesc(char),
                 })
             end,
             delete = function(char)
+                if char:byte() < 32 then
+                    return
+                end
                 return M.get_selections({
                     char = char,
                     pattern = "^(.)().-(.)()$",

--- a/lua/nvim-surround/input.lua
+++ b/lua/nvim-surround/input.lua
@@ -5,8 +5,8 @@ local M = {}
 ---@nodiscard
 M.get_char = function()
     local ret_val, char_num = pcall(vim.fn.getchar)
-    -- Return nil if error (e.g. <C-c>) or for control characters
-    if not ret_val or type(char_num) ~= "number" or char_num < 32 then
+    -- Return nil if error (e.g. <C-c>) or for <Esc>/<C-[> (ascii code 27)
+    if not ret_val or type(char_num) ~= "number" or char_num == 27 then
         return nil
     end
     local char = vim.fn.nr2char(char_num)


### PR DESCRIPTION
BREAKING CHANGE: User defined `invalid_key_behavior` handlers will be activated for special keys that don't have defined `surrounds`.