### PR TITLE
feat: Support control characters for modifying `surrounds`. (#179)

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -354,14 +354,6 @@ M.get_selections = function(args)
     end
 end
 
--- Translate Vim-style key notation to terminal code, for usage in `surrounds` keys.
----@param str string A Vim-style key notation (e.g. "<Cr>")
----@return string? @The key notation translated to terminal codes (e.g. "\r")
----@nodiscard
-M.termcode = function(str)
-    return vim.api.nvim_replace_termcodes(str, true, true, true)
-end
-
 --[====================================================================================================================[
                                                 End of Helper Functions
 --]====================================================================================================================]
@@ -600,6 +592,8 @@ M.translate_opts = function(user_opts)
                 "nvim-surround"
             )
         end
+        -- Support Vim's notation for special characters
+        char = vim.api.nvim_replace_termcodes(char, true, true, true)
         -- Check if the delimiter has not been disabled
         if not user_surround then
             opts.surrounds[char] = false

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -227,14 +227,23 @@ M.default_opts = {
         },
         invalid_key_behavior = {
             add = function(char)
+                if char:find("%c") then
+                    return
+                end
                 return { { char }, { char } }
             end,
             find = function(char)
+                if char:find("%c") then
+                    return
+                end
                 return M.get_selection({
                     pattern = vim.pesc(char) .. ".-" .. vim.pesc(char),
                 })
             end,
             delete = function(char)
+                if char:find("%c") then
+                    return
+                end
                 return M.get_selections({
                     char = char,
                     pattern = "^(.)().-(.)()$",
@@ -343,6 +352,14 @@ M.get_selections = function(args)
     else
         vim.notify("Invalid key provided for `:h nvim-surround.config.get_selections()`.", vim.log.levels.ERROR)
     end
+end
+
+-- Translate Vim-style key notation to terminal code, for usage in `surrounds` keys.
+---@param str string A Vim-style key notation (e.g. "<Cr>")
+---@return string? @The key notation translated to terminal codes (e.g. "\r")
+---@nodiscard
+M.termcode = function(str)
+    return vim.api.nvim_replace_termcodes(str, true, true, true)
 end
 
 --[====================================================================================================================[

--- a/lua/nvim-surround/input.lua
+++ b/lua/nvim-surround/input.lua
@@ -4,12 +4,11 @@ local M = {}
 ---@return string? @The input character, or nil if a control character is pressed.
 ---@nodiscard
 M.get_char = function()
-    local ret_val, char_num = pcall(vim.fn.getchar)
-    -- Return nil if error (e.g. <C-c>) or for control characters
-    if not ret_val or type(char_num) ~= "number" or char_num < 32 then
+    local ret_val, char = pcall(vim.fn.getcharstr)
+    -- Return nil if error (e.g. <C-c>) or for <Esc>/<C-[> (ascii code 27)
+    if not ret_val or char == "\27" then
         return nil
     end
-    local char = vim.fn.nr2char(char_num)
     return char
 end
 


### PR DESCRIPTION
- config.get_char can now return strings that represent control characters, both single-byte (e.g. Ctrl+something) and multi-byte (e.g. Alt+something)
- New helper function `config.termcode` for generating keys for `surrounds` that use control characters.

BREAKING CHANGE: User defined `invalid_key_behavior` handlers will be activated for control characters that don't have defined `surrounds`.