### PR TITLE
Fix handling of whitespace when delimiters are on separate lines

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -352,19 +352,9 @@ end
 ---@return delimiter_pair|nil @A pair of delimiters for the given input, or nil if not applicable.
 ---@nodiscard
 M.get_delimiters = function(char, line_mode)
-    if not char then
-        return nil
-    end
-
     char = M.get_alias(char)
     -- Get the delimiters, using invalid_key_behavior if the add function is undefined for the character
-    local delimiters = (function()
-        if M.get_add(char) then
-            return M.get_add(char)(char)
-        else
-            return M.get_opts().surrounds.invalid_key_behavior.add(char)
-        end
-    end)()
+    local delimiters = M.get_add(char)(char)
     -- Add new lines if the addition is done line-wise
     if delimiters and line_mode then
         local lhs = delimiters[1]

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -367,8 +367,15 @@ M.get_delimiters = function(char, line_mode)
     end)()
     -- Add new lines if the addition is done line-wise
     if delimiters and line_mode then
-        table.insert(delimiters[2], 1, "")
-        table.insert(delimiters[1], "")
+        local lhs = delimiters[1]
+        local rhs = delimiters[2]
+
+        -- Trim whitespace after the leading delimiter and before the trailing delimiter
+        lhs[#lhs] = lhs[#lhs]:gsub("%s+$", "")
+        rhs[1] = rhs[1]:gsub("^%s+", "")
+
+        table.insert(rhs, 1, "")
+        table.insert(lhs, "")
     end
 
     return delimiters

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -80,19 +80,17 @@ M.visual_surround = function(args)
     local curpos = buffer.get_curpos()
     -- Get a character and selection from the user
     local ins_char = input.get_char()
+
+    if vim.fn.visualmode() == "V" then
+        args.line_mode = true
+    end
     local delimiters = config.get_delimiters(ins_char, args.line_mode)
     local first_pos, last_pos = buffer.get_mark("<"), buffer.get_mark(">")
     if not delimiters or not first_pos or not last_pos then
         return
     end
 
-    -- Add the right delimiter first to ensure correct indexing
-    if vim.fn.visualmode() == "V" then -- Visual line mode case (need to create new lines)
-        table.insert(delimiters[2], 1, "")
-        table.insert(delimiters[1], "")
-        buffer.insert_text({ last_pos[1], #buffer.get_line(last_pos[1]) + 1 }, delimiters[2])
-        buffer.insert_text(first_pos, delimiters[1])
-    elseif vim.fn.visualmode() == "\22" then -- Visual block mode case (add delimiters to every line)
+    if vim.fn.visualmode() == "\22" then -- Visual block mode case (add delimiters to every line)
         if vim.o.selection == "exclusive" then
             last_pos[2] = last_pos[2] - 1
         end

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -199,25 +199,19 @@ M.change_surround = function(args)
         -- closing delimiter if only whitespace exists between it and the
         -- beginning of the line.
 
-        -- Column number of end of opening selection
-        local xpos = selections.left.last_pos[2]
         local space_begin, space_end = buffer.get_line(selections.left.last_pos[1]):find("%s*$")
-
-        if space_begin - 1 <= xpos then -- Whitespace is adjacent to opening delimiter
+        if space_begin - 1 <= selections.left.last_pos[2] then -- Whitespace is adjacent to opening delimiter
             -- Trim trailing whitespace from opening delimiter
             delimiters[1][#delimiters[1]] = delimiters[1][#delimiters[1]]:gsub("%s+$", "")
-            -- Adjust selection to include trailing whitespace, so it gets removed
+            -- Grow selection end to include trailing whitespace, so it gets removed
             selections.left.last_pos[2] = space_end
         end
 
-        -- Column number of beginning of closing selection
-        xpos = selections.right.first_pos[2]
         space_begin, space_end = buffer.get_line(selections.right.first_pos[1]):find("^%s*")
-
-        if space_end + 1 >= xpos then -- Whitespace is adjacent to closing delimiter
+        if space_end + 1 >= selections.right.first_pos[2] then -- Whitespace is adjacent to closing delimiter
             -- Trim leading whitespace from closing delimiter
             delimiters[2][1] = delimiters[2][1]:gsub("^%s+", "")
-            -- Adjust selection to exclude leading whitespace, so it remains unchanged
+            -- Shrink selection beginning to exclude leading whitespace, so it remains unchanged
             selections.right.first_pos[2] = space_end + 1
         end
 

--- a/tests/basics_spec.lua
+++ b/tests/basics_spec.lua
@@ -147,6 +147,84 @@ describe("nvim-surround", function()
         check_lines({ "(sample_text)" })
     end)
 
+    it("properly handles whitespace next to line boundaries", function()
+        set_lines({ "sample_text" })
+        vim.cmd("normal ySS{")
+        check_lines({ "{", "sample_text", "}" })
+        vim.cmd("normal cs}[")
+        check_lines({ "[", "sample_text", "]" })
+
+        set_lines({ "(", "    sample_text", ")" })
+        vim.cmd("normal cs)<")
+        check_lines({ "<", "    sample_text", ">" })
+
+        set_lines({
+            "    <texta",
+            "        textb",
+            "    >",
+        })
+        vim.cmd("normal cs><")
+        check_lines({
+            "    < texta",
+            "        textb",
+            "    >",
+        })
+        vim.cmd("normal cs>{")
+        check_lines({
+            "    {  texta",
+            "        textb",
+            "    }",
+        })
+        vim.cmd("normal cs{]")
+        check_lines({
+            "    [ texta",
+            "        textb",
+            "    ]",
+        })
+        vim.cmd("normal cs[)")
+        check_lines({
+            "    (texta",
+            "        textb",
+            "    )",
+        })
+
+        set_lines({
+            "    {texta",
+            "        textb",
+            "    textc}",
+        })
+        vim.cmd("normal cs{{")
+        check_lines({
+            "    { texta",
+            "        textb",
+            "    textc }",
+        })
+        vim.cmd("normal cs{{")
+        check_lines({
+            "    { texta",
+            "        textb",
+            "    textc }",
+        })
+        vim.cmd("normal cs}{")
+        check_lines({
+            "    {  texta",
+            "        textb",
+            "    textc  }",
+        })
+        vim.cmd("normal cs{}")
+        check_lines({
+            "    { texta",
+            "        textb",
+            "    textc }",
+        })
+        vim.cmd("normal cs{}")
+        check_lines({
+            "    {texta",
+            "        textb",
+            "    textc}",
+        })
+    end)
+
     it("can surround charwise visual selections", function()
         set_lines({ "this is", "a full", "sentence" })
         set_curpos({ 1, 2 })


### PR DESCRIPTION
Currently, there are some issues with linewise surround insertion and changing surrounds where the opening delimiter has only whitespace between it and the end of the line or where the closing delimiter has only whitespace between it and the beginning of the line.

```
foo
```
For instance, assuming default configuration, if `ySS{` is run on the above example text, the result is the following, with `·` marking space characters:
```
{·
····foo
}
```
If `cs{[` is then run, the result is:
```
[·
····foo
·]
```
If `cs]{` is then run, the result is:
```
{··
····foo
··}
```

`cs{}` will remove the trailing spaces after `{` and the leading spaces before `}` one by one, including the leading indentation before `}` if the entire text were space-indented beforehand. Correctly choosing between the left-hand and right-hand delimiter bindings can avoid the issue, but the current behaviour is neither useful nor intuitive.

This PR fixes the issue with insertion by automatically stripping whitespace from delimiters when `line_mode` is on. It also refactors linewise visual surround to use `line_mode`, so as to avoid duplicate logic.

It fixes the issue with changing surrounds by checking for leading and trailing whitespace in `change_surround()`, and:
* If the opening delimiter is followed by only whitespace until the end of the line, the edit selection for the opening delimiter is expanded until the end of the line and any trailing whitespace in the delimiter to be inserted is removed before inserting it.
* If the closing delimiter is preceded by only whitespace until the beginning of the line, the edit selection for the closing delimiter is shrunk to exclude all preceding whitespace and any leading whitespace in the delimiter to be inserted is removed before inserting it.

The end result is that it generally doesn't matter whether the left-hand or right-hand bindings are used when inserting or changing surrounds where the body text is on separate lines. If there is non-whitespace between the opening delimiter and the end of the line or between the closing delimiter and the beginning of the line, the behaviour of `cs`/`change_surround()` is unchanged (per delimiter), which is probably desirable.

In this case automatically stripping whitespace after the opening delimiter would be both visible and surprising, and the whitespace between the closing delimiter and the beginning of the line couldn't be part of the line's indent, so the existing behaviour is reasonable here, too.

Highlighting of delimiters is not changed. The left-hand bindings highlight the spaces they match, and the highlighting that is displayed is the same regardless of whether the new logic applies.

As an aside, though not touched upon in this PR, it's arguable that changing the behaviour of `change_surround()` to always strip whitespace, such that `cs()` always results in enclosing parentheses with no space padding at all and `cs)(` or `cs((` always results in enclosing parentheses with a single space of padding, could be desirable. I think this can actually be changed just by changing the relevant patterns in your config to match ` *` instead of ` ?` (zero or more instead of zero or one spaces), so a change to `nvim-surround` proper isn't necessary unless it's decided that this would be a better default behaviour.