### PR TITLE
Implement change_line mapping

### DIFF
--- a/lua/nvim-surround/cache.lua
+++ b/lua/nvim-surround/cache.lua
@@ -2,7 +2,7 @@ local M = {}
 
 -- These variables hold cache values for dot-repeating the three actions
 
----@type { line_mode: boolean }
+---@type { delimiters: string[][]|nil, line_mode: boolean }
 M.normal = {}
 ---@type { char: string }
 M.delete = {}

--- a/lua/nvim-surround/cache.lua
+++ b/lua/nvim-surround/cache.lua
@@ -6,7 +6,7 @@ local M = {}
 M.normal = {}
 ---@type { char: string }
 M.delete = {}
----@type { del_char: string, add_delimiters: add_func }
+---@type { del_char: string, add_delimiters: add_func, line_mode: boolean }
 M.change = {}
 
 -- Sets the callback function for dot-repeating.

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -16,6 +16,7 @@ M.default_opts = {
         visual_line = "gS",
         delete = "ds",
         change = "cs",
+        change_line = "cS",
     },
     surrounds = {
         ["("] = {
@@ -706,10 +707,25 @@ M.set_keymaps = function(args)
     M.set_keymap({
         mode = "n",
         lhs = "<Plug>(nvim-surround-change)",
-        rhs = require("nvim-surround").change_surround,
+        rhs = function()
+            return require("nvim-surround").change_surround({ line_mode = false })
+        end,
         opts = {
             buffer = args.buffer,
             desc = "Change a surrounding pair",
+            expr = true,
+            silent = true,
+        },
+    })
+    M.set_keymap({
+        mode = "n",
+        lhs = "<Plug>(nvim-surround-change-line)",
+        rhs = function()
+            return require("nvim-surround").change_surround({ line_mode = true })
+        end,
+        opts = {
+            buffer = args.buffer,
+            desc = "Change a surrounding pair, putting replacements on new lines",
             expr = true,
             silent = true,
         },
@@ -804,6 +820,15 @@ M.set_keymaps = function(args)
         rhs = "<Plug>(nvim-surround-change)",
         opts = {
             desc = "Change a surrounding pair",
+        },
+    })
+    M.set_keymap({
+        name = "change",
+        mode = "n",
+        lhs = M.get_opts().keymaps.change_line,
+        rhs = "<Plug>(nvim-surround-change-line)",
+        opts = {
+            desc = "Change a surrounding pair, putting replacements on new lines",
         },
     })
 end

--- a/tests/basics_spec.lua
+++ b/tests/basics_spec.lua
@@ -432,6 +432,48 @@ describe("nvim-surround", function()
         check_lines({ "[", "", "]" })
     end)
 
+    it("can change delimiter pairs on new lines", function()
+        set_lines({
+            "require'nvim-surround'.setup(args)",
+        })
+        set_curpos({ 1, 29 })
+        vim.cmd("normal cS))")
+        check_lines({
+            "require'nvim-surround'.setup(",
+            "args",
+            ")",
+        })
+        set_curpos({ 2, 1 })
+        vim.cmd([[normal ysab}]])
+        set_curpos({ 1, 29 })
+        vim.cmd("normal cS}]")
+        check_lines({
+            "require'nvim-surround'.setup[",
+            "(",
+            "args",
+            ")",
+            "]",
+        })
+        vim.cmd("normal cS]{")
+        check_lines({
+            "require'nvim-surround'.setup{",
+            "",
+            "(",
+            "args",
+            ")",
+            "",
+            "}",
+        })
+
+        set_lines({ "()" })
+        vim.cmd("normal cSbb")
+        check_lines({ "(", "", ")" })
+
+        set_lines({ "{", "", "}" })
+        vim.cmd("normal cSBB")
+        check_lines({ "{", "", "", "", "}" })
+    end)
+
     it("can handle invalid key behavior", function()
         set_lines({ "sample text" })
         vim.cmd("normal yss|")


### PR DESCRIPTION
This PR addresses #244.

As of this commit, given the input, where `|` denotes the cursor position:
```
let x = foo(args|);
```

`cS)(` yields:
```
let x = foo(|
    args
);
```

The indentation of `args` depends on the indentation rules for the filetype.

We still need to iron out behavior for complex surrounds like HTML tags and functions. Currently, given the input, where `|` denotes the cursor position:
```
let x = foo(args|);
```

Both `csf` AND `cSf` with `bar` would yield:
```
let x = |bar(args);
```

This follows because the change target selection is just the `foo`. However, users may instead want the result to be:
```
let x = |bar(
    args
);
```

This is more useful because otherwise, `cs` and `cS` would be exhibiting the same behavior.