### PR TITLE
fix: line surrounds are properly dot-repeatable

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -638,7 +638,13 @@ M.set_keymaps = function(args)
         mode = "n",
         lhs = "<Plug>(nvim-surround-normal-cur)",
         rhs = function()
-            return "^" .. tostring(vim.v.count1) .. "<Plug>(nvim-surround-normal)g_"
+            local count_string = ""
+            if vim.v.count1 > 1 then
+                count_string = vim.v.count1 - 1 .. "j"
+            end
+            return "<Plug>(nvim-surround-normal)<Cmd>lua vim.cmd.normal({'^v"
+                .. count_string
+                .. "g_', bang = true})<CR>"
         end,
         opts = {
             buffer = args.buffer,

--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -638,13 +638,7 @@ M.set_keymaps = function(args)
         mode = "n",
         lhs = "<Plug>(nvim-surround-normal-cur)",
         rhs = function()
-            local count_string = ""
-            if vim.v.count1 > 1 then
-                count_string = vim.v.count1 - 1 .. "j"
-            end
-            return "<Plug>(nvim-surround-normal)<Cmd>lua vim.cmd.normal({'^v"
-                .. count_string
-                .. "g_', bang = true})<CR>"
+            return "<Plug>(nvim-surround-normal)Vg_"
         end,
         opts = {
             buffer = args.buffer,

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -162,6 +162,11 @@ describe("configuration", function()
         check_lines({
             [[And "jump forwards and backwards" to the (nearest) surround.]],
         })
+        vim.cmd("normal yss)")
+        assert.are.same(get_curpos(), { 1, 31 })
+        check_lines({
+            [[(And "jump forwards and backwards" to the (nearest) surround.)]],
+        })
     end)
 
     it("can move the cursor to the beginning of an action", function()

--- a/tests/dot_repeat_spec.lua
+++ b/tests/dot_repeat_spec.lua
@@ -182,7 +182,7 @@ describe("dot-repeat", function()
 
     it("can perform a dot-repeat addition, moving the cursor to the beginning of the surround", function()
         require("nvim-surround").buffer_setup({
-            move_cursor = true,
+            move_cursor = "begin",
         })
 
         set_lines({

--- a/tests/dot_repeat_spec.lua
+++ b/tests/dot_repeat_spec.lua
@@ -178,6 +178,15 @@ describe("dot-repeat", function()
         vim.cmd("normal ysiwfhi" .. cr)
         vim.cmd("normal j.j.j.3k")
         check_curpos({ 1, 3 })
+        vim.cmd("normal yss]")
+        vim.cmd("normal j.j.j.3k")
+        check_curpos({ 1, 3 })
+        check_lines({
+            "[hi(here)]",
+            "[hi(there) is]",
+            "[hi(another)]",
+            "[hi(line)]",
+        })
     end)
 
     it("can perform a dot-repeat addition, moving the cursor to the beginning of the surround", function()


### PR DESCRIPTION
Also corrects a dot-repeat test

Sorry, it seems https://github.com/kylechui/nvim-surround/pull/261 got closed after an emotional rollercoaster. In any case the tests are working now. Thanks for taking a look!