### PR TITLE
fix: Translate char to termcodes when reading input (#271)

### DIFF
--- a/lua/nvim-surround/input.lua
+++ b/lua/nvim-surround/input.lua
@@ -9,7 +9,8 @@ M.get_char = function()
     if not ok or char == "\27" then
         return nil
     end
-    return char
+    -- Call this function, because config.translate_opts() does too
+    return vim.api.nvim_replace_termcodes(char, true, true, true)
 end
 
 -- Gets a string input from the user.


### PR DESCRIPTION
In ‘config.translate_opts()’, the chars specified in the ‘surrounds’
portion of a configuration are translated to Vim internal representation
in order to support special characters.  As a result though, we need to
actually translate the users input.  Otherwise configuration of certain
Unicode characters such as U+2019 RIGHT SINGLE QUOTATION MARK may not
work.
