### PR TITLE
fix: correctly name keymap for change_line

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -823,7 +823,7 @@ M.set_keymaps = function(args)
         },
     })
     M.set_keymap({
-        name = "change",
+        name = "change_line",
         mode = "n",
         lhs = M.get_opts().keymaps.change_line,
         rhs = "<Plug>(nvim-surround-change-line)",


### PR DESCRIPTION
This caused me a bug where the keymap for `change` would be disabled when configuring `change_line = false`

The bug occurs because of the logic in `set_keymap`
```lua
    -- If the keymap is disabled
    if not args.lhs then
        -- If the mapping is disabled globally, do nothing
        if not M.user_opts.keymaps[args.name] then
            return
        end
        -- Otherwise disable the global keymap
        args.lhs = M.user_opts.keymaps[args.name]
        args.rhs = "<NOP>"
    end
    vim.keymap.set(args.mode, args.lhs, args.rhs, args.opts)
```

Entering this function for `change_line` we get `lhs = false` (correct) but since `name = "change"` (incorrect) it thinks that the mapping is not globally disabled so it overrides the lhs for `change` with `"<NOP>"`

The problem is resolved by correctly giving the `change_line` keymap its own name (like `visual_line` etc. already do)


