### PR TITLE
WIP: Stabilize cursor

### DIFF
--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -234,7 +234,8 @@ M.insert_text = function(pos, text, cursor)
 
     if cursor then
         if M.comes_before(pos, cursor) then
-            return {cursor[1] + math.min(#text - 1, 0), cursor[2] + #text[#text]}
+            if text == {} then text = {''} end
+            return {cursor[1] + #text - 1, cursor[2] + #text[#text]}
         else
             return cursor
         end
@@ -278,7 +279,7 @@ M.change_selection = function(selection, text, cursor)
         else
             local column = cursor[2]
             if cursor[1] == selection.last_pos[1] then
-                if text == {} then text = '' end
+                if text == {} then text = {''} end
                 if #text == 1 then
                     column = cursor[2] - (selection.last_pos[2] - selection.first_pos[2] + 1) + #text[#text]
                 else

--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -235,7 +235,15 @@ M.insert_text = function(pos, text, cursor)
     if cursor then
         if M.comes_before(pos, cursor) then
             if text == {} then text = {''} end
-            return {cursor[1] + #text - 1, cursor[2] + #text[#text]}
+            local column = cursor[2]
+            if cursor[1] == pos[1] then
+                if #text == 1 then
+                    column = column + #text[#text]
+                else
+                    column = column - pos[2] + 1 + #text[#text]
+                end
+            end
+            return {cursor[1] + #text - 1, column}
         else
             return cursor
         end
@@ -278,15 +286,15 @@ M.change_selection = function(selection, text, cursor)
             return selection.first_pos
         else
             local column = cursor[2]
+            if text == {} then text = {''} end
             if cursor[1] == selection.last_pos[1] then
-                if text == {} then text = {''} end
                 if #text == 1 then
                     column = cursor[2] - (selection.last_pos[2] - selection.first_pos[2] + 1) + #text[#text]
                 else
                     column = cursor[2] - selection.last_pos[2] + #text[#text]
                 end
             end
-            return  {cursor[1] + math.max(#text - 1, 0) - (selection.last_pos[1] - selection.first_pos[1]), column}
+            return  {cursor[1] + #text - 1 - (selection.last_pos[1] - selection.first_pos[1]), column}
         end
     end
 end

--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -30,7 +30,7 @@ M.restore_curpos = function(pos)
     if config.get_opts().move_cursor == "begin" then
         M.set_curpos(pos.first_pos)
     elseif not config.get_opts().move_cursor then
-        M.set_curpos(pos.old_pos)
+        -- M.set_curpos(pos.old_pos)
     end
 end
 
@@ -228,75 +228,27 @@ end
 -- Adds some text into the buffer at a given position.
 ---@param pos position The position to be inserted at.
 ---@param text text The text to be added.
-M.insert_text = function(pos, text, cursor)
+M.insert_text = function(pos, text)
     pos[2] = math.min(pos[2], #M.get_line(pos[1]) + 1)
     vim.api.nvim_buf_set_text(0, pos[1] - 1, pos[2] - 1, pos[1] - 1, pos[2] - 1, text)
-
-    if cursor then
-        if M.comes_before(pos, cursor) then
-            if text == {} then text = {''} end
-            local column = cursor[2]
-            if cursor[1] == pos[1] then
-                if #text == 1 then
-                    column = column + #text[#text]
-                else
-                    column = column - pos[2] + 1 + #text[#text]
-                end
-            end
-            return {cursor[1] + #text - 1, column}
-        else
-            return cursor
-        end
-    end
 end
 
 -- Deletes a given selection from the buffer.
 ---@param selection selection The given selection.
-M.delete_selection = function(selection, cursor)
+M.delete_selection = function(selection)
     local first_pos, last_pos = selection.first_pos, selection.last_pos
     vim.api.nvim_buf_set_text(0, first_pos[1] - 1, first_pos[2] - 1, last_pos[1] - 1, last_pos[2], {})
-    if cursor then
-        if M.comes_before(cursor, selection.first_pos) then
-            return cursor
-        elseif M.comes_before(cursor, selection.last_pos) then
-            return selection.first_pos
-        else
-            local column = cursor[2]
-            if cursor[1] == selection.last_pos[1] then
-                column = cursor[2] - (selection.last_pos[2] - selection.first_pos[2] + 1)
-            end
-            return {cursor[1] - (selection.last_pos[1] - selection.first_pos[1]), column}
-        end
-    end
 end
 
 -- Replaces a given selection with a set of lines.
 ---@param selection selection|nil The given selection.
 ---@param text text The given text to replace the selection.
-M.change_selection = function(selection, text, cursor)
+M.change_selection = function(selection, text)
     if not selection then
         return
     end
     local first_pos, last_pos = selection.first_pos, selection.last_pos
     vim.api.nvim_buf_set_text(0, first_pos[1] - 1, first_pos[2] - 1, last_pos[1] - 1, last_pos[2], text)
-    if cursor then
-        if M.comes_before(cursor, selection.first_pos) then
-            return cursor
-        elseif M.comes_before(cursor, selection.last_pos) then
-            return selection.first_pos
-        else
-            local column = cursor[2]
-            if text == {} then text = {''} end
-            if cursor[1] == selection.last_pos[1] then
-                if #text == 1 then
-                    column = cursor[2] - (selection.last_pos[2] - selection.first_pos[2] + 1) + #text[#text]
-                else
-                    column = cursor[2] - selection.last_pos[2] + #text[#text]
-                end
-            end
-            return  {cursor[1] + #text - 1 - (selection.last_pos[1] - selection.first_pos[1]), column}
-        end
-    end
 end
 
 --[====================================================================================================================[

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -73,7 +73,7 @@ M.normal_surround = function(args)
     })
 
     if args.line_mode then
-        preserve(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
+        Preserve_cusor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
     end
     M.pending_surround = false
 end
@@ -169,18 +169,6 @@ M.delete_surround = function(args)
         new_pos = buffer.delete_selection(selections.right, new_pos)
         new_pos = buffer.delete_selection(selections.left, new_pos)
 
-        local left_sel = selections.left
-        local new_pos = args.curpos
-        if left_sel == nil then return end
-        if buffer.comes_before(left_sel.first_pos, args.curpos) and
-            buffer.comes_before(args.curpos, left_sel.last_pos) then
-            new_pos = left_sel.first_pos
-        else
-            if new_pos[1] == left_sel.last_pos[1] then
-                new_pos[2] = new_pos[2] + left_sel.first_pos[2] - left_sel.last_pos[2] - 1
-            end
-            new_pos[1] = new_pos[1] - left_sel.last_pos[1] + left_sel.first_pos[1]
-        end
         buffer.restore_curpos({
             first_pos = selections.left.first_pos,
             old_pos = new_pos,

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -73,7 +73,7 @@ M.normal_surround = function(args)
     })
 
     if args.line_mode then
-        Preserve_cusor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
+        Preserve_cursor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
     end
     M.pending_surround = false
 end
@@ -144,7 +144,7 @@ M.visual_surround = function(args)
         first_pos = first_pos,
         old_pos = new_pos,
     })
-    Preserve_cusor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
+    Preserve_cursor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
 end
 
 -- Delete a surrounding delimiter pair, if it exists.
@@ -173,7 +173,7 @@ M.delete_surround = function(args)
             first_pos = selections.left.first_pos,
             old_pos = new_pos,
         })
-        Preserve_cusor(
+        Preserve_cursor(
             config.get_opts().indent_lines,
             selections.left.first_pos[1],
             selections.left.first_pos[1] + selections.right.first_pos[1] - selections.left.last_pos[1]
@@ -237,14 +237,14 @@ M.change_surround = function(args)
             local first_pos = selections.left.first_pos
             local last_pos = selections.right.last_pos
 
-            Preserve_cusor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
+            Preserve_cursor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
         end
     end
 
     cache.set_callback("v:lua.require'nvim-surround'.change_callback")
 end
 
-function Preserve_cusor(func, ...)
+function Preserve_cursor(func, ...)
     -- local line, col = table.unpack(vim.api.nvim_win_get_cursor(0))
     local line, col = unpack(vim.api.nvim_win_get_cursor(0))
     local len_before = vim.api.nvim_get_current_line():len()

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -140,11 +140,11 @@ M.visual_surround = function(args)
         new_pos = buffer.insert_text(first_pos, delimiters[1], new_pos)
     end
 
-    Preserve_cusor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
     buffer.restore_curpos({
         first_pos = first_pos,
         old_pos = new_pos,
     })
+    Preserve_cusor(config.get_opts().indent_lines, first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
 end
 
 -- Delete a surrounding delimiter pair, if it exists.


### PR DESCRIPTION
I tried to get vim-surround to always keep the cursor on the same character when adding/changing/deleting surroundings, if the `move_cursor` option is false. And if the cursor is inside a region that gets changed, it will be moved to the first character in that region. I prefer this to the current behavior of `move_cursor = false` because it means I don't need to "re-orient" myself after making a change with nvim-surround.
Would you be interested in merging this?

Some people might be used to the current, so it might be good to keep an option for the old behaviour. I could add that.

Some examples: The uppercase letter marks the cursor position

```
 Old text           Command       current behavior      this PR
-------------------------------------------------------------------------
 one mAp pan        ysaw)         one (Map) pan         one (mAp) pan
 one (pAn) man      cs)[          one [ Pan ] man       one [ pAn ] pan
 gg(arg) + X + one  dsf           arg + x + One         arg + X + one
 sOme               ySawfgg<CR>   gG(                   gg(
                                      some                  sOme
                                  )                     )
```


 gg(arg) + X + one  dsf           arg + X + one         