### PR TITLE
Added a reference to relevant helptexts for motions

### DIFF
--- a/doc/nvim-surround.txt
+++ b/doc/nvim-surround.txt
@@ -47,7 +47,8 @@ The primary way of adding a new pair to the buffer is via the normal-mode *ys*
 operator, which stands for "you surround". It can be used via
 `ys{motion}{char}`, which surrounds a given {motion} with a delimiter pair
 associated with {char}. For example, `ysa")` means "you surround around quotes
-with parentheses".
+with parentheses". For more information on {motion}, check `:h motion` and 
+`:h text-objects`.
 
 In all of the following examples, the `*` denotes the cursor position:
 


### PR DESCRIPTION
Regarding discussion https://github.com/kylechui/nvim-surround/discussions/259
Added a reference to the relevant help text for motions, specifically for people who aren't super familiar with vim and never heard of text objects.

I think that the `:h motion` part is pretty facepalm-worthy obvious, but for someone who doesn't know about text-objects, I think it'd be hard to find info on `a` and `i`. But it would feel weird to give the suggestion for `:h text-objects` without mentioning `:h motion`.