### PR TITLE
docs: added a reference to relevant helptexts for motions

### DIFF
--- a/doc/nvim-surround.txt
+++ b/doc/nvim-surround.txt
@@ -45,9 +45,9 @@ and "modifying" (deleting/changing) delimiter pairs.
 
 The primary way of adding a new pair to the buffer is via the normal-mode *ys*
 operator, which stands for "you surround". It can be used via
-`ys{motion}{char}`, which surrounds a given {motion} with a delimiter pair
-associated with {char}. For example, `ysa")` means "you surround around quotes
-with parentheses".
+`ys{motion}{char}`, which surrounds a given |motion| or |text-object| with a
+delimiter pair associated with {char}. For example, `ysa")` means "you surround
+around quotes with parentheses".
 
 In all of the following examples, the `*` denotes the cursor position:
 


### PR DESCRIPTION
Re: discussion https://github.com/kylechui/nvim-surround/discussions/259
Added a reference to the relevant help text for motions, specifically for people who aren't super familiar with vim and never heard of text objects.

I think that the `:h motion` part is pretty facepalm-worthy obvious, but for someone who doesn't know about text-objects, I think it'd be hard to find info on `a` and `i`. But it would feel weird to give the suggestion for `:h text-objects` without mentioning `:h motion`.