### PR TITLE
feat: allow overriding keymap description

### DIFF
--- a/doc/nvim-surround.txt
+++ b/doc/nvim-surround.txt
@@ -299,7 +299,7 @@ the `(` surround, call:
 The `keymaps` table defines the keymaps used to perform surround actions. The
 general rule is that if the key ends in "_line", the delimiter pair is added
 on new lines. If the key ends in "_cur", the surround is performed around the
-current line.
+current line. Setting a key to `false` will disable it.
 
 The default configuration is as follows:
 >lua
@@ -316,6 +316,11 @@ The default configuration is as follows:
         change = "cs",
         change_line = "cS",
     },
+<
+
+You can also provide a table for a keymap to override the description:
+>lua
+  normal = { mapping = "ys", desc = "surround: motion" },
 <
 
 Additionally, there is a corresponding set of |<Plug>| mappings that one may

--- a/lua/nvim-surround/annotations.lua
+++ b/lua/nvim-surround/annotations.lua
@@ -31,7 +31,7 @@
 ---@field change change_table
 
 ---@class options
----@field keymaps table<string, string>
+---@field keymaps table<string, {mapping: string|false, desc: string|nil}>
 ---@field surrounds table<string, surround>
 ---@field aliases table<string, string|string[]>
 ---@field highlight { duration: integer }
@@ -54,7 +54,7 @@
 ---@field change user_change
 
 ---@class user_options
----@field keymaps table<string, false|string>
+---@field keymaps table<string, false|string|{mapping: string, desc: string|nil}>
 ---@field surrounds table<string, false|user_surround>
 ---@field aliases table<string, false|string|string[]>
 ---@field highlight { duration: false|integer }


### PR DESCRIPTION
## Description
The fields of `keymaps` will now accept either a mapping as a string or a table that includes a description override for that mapping.

## Overview
Users can now provide a table for a keymap which will include the `mapping` and a `desc` to override the description. This is useful for which-key, since the default descriptions are verbose and get truncated.

Example:
```lua
keymaps = {
   insert = { mapping = "<C-g>s", desc = "surround cursor",
   insert_line = false,
   normal = { mapping = "gs" },
   normal_cur = { mapping = "gss", desc = "Add a surrounding pair around the current line (normal mode)" },
   ...
}
```

I also went ahead and did a few minor refactors, such as removing duplication of default keymap descriptions.

Please let me know if this isn't wanted or if there should be a different way to implement it. THANKS!

