### PR TITLE
feat!: Rewrite user configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~
+.tests
+doc/tags

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,3 +1,39 @@
-vim.opt.expandtab = true
+local M = {}
 
-require("nvim-surround").setup()
+function M.root(root)
+    local f = debug.getinfo(1, "S").source:sub(2)
+    return vim.fn.fnamemodify(f, ":p:h:h") .. "/" .. (root or "")
+end
+
+---@param plugin string
+function M.load(plugin)
+    local name = plugin:match(".*/(.*)")
+    local package_root = M.root(".tests/site/pack/deps/start/")
+    if not vim.loop.fs_stat(package_root .. name) then
+        print("Installing " .. plugin)
+        vim.fn.mkdir(package_root, "p")
+        vim.fn.system({
+            "git",
+            "clone",
+            "--depth=1",
+            "https://github.com/" .. plugin .. ".git",
+            package_root .. "/" .. name,
+        })
+    end
+end
+
+function M.setup()
+    vim.cmd([[set runtimepath=$VIMRUNTIME]])
+    vim.opt.runtimepath:append(M.root())
+    vim.opt.packpath = { M.root(".tests/site") }
+    M.load("nvim-lua/plenary.nvim")
+    vim.env.XDG_CONFIG_HOME = M.root(".tests/config")
+    vim.env.XDG_DATA_HOME = M.root(".tests/data")
+    vim.env.XDG_STATE_HOME = M.root(".tests/state")
+    vim.env.XDG_CACHE_HOME = M.root(".tests/cache")
+
+    vim.opt.expandtab = true
+    require("nvim-surround").setup()
+end
+
+M.setup()


### PR DESCRIPTION
This commit will deprecate the existing `setup` and `buffer_setup` function calls, in line with [this blog post](https://mrcjkb.dev/posts/2023-08-22-setup.html). I believe that plugins, by default, should merely expose functionality but not actively modify user configuration at all. The goal is to have the installation script in the README contain the current "default" configuration, and any changes can be made by users directly. While this results in more code for the end user, I think that the reduced complexity and layers of abstraction will ultimately help users better understand the plugin and have more control for how it behaves.

The changes will be:
- `setup(...)` &rarr; `vim.g.nvim_surround`
- `buffer_setup(...)` &rarr; `vim.b.nvim_surround`