### PR TITLE
fix(dot-repeat): clear dot-repeat after indentation

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -248,6 +248,7 @@ M.default_opts = {
         -- Only re-indent the selection if a formatter is set up already
         if start < stop and (b.equalprg ~= "" or b.indentexpr ~= "" or b.cindent or b.smartindent or b.lisp) then
             vim.cmd(string.format("silent normal! %dG=%dG", start, stop))
+            require("nvim-surround.cache").set_callback("")
         end
     end,
 }


### PR DESCRIPTION
Do not set dot repeat to indentation as it is misleading and messes with undo.

As of now, the default indentation function will perform its action and thus will set the dot-repeat to indent the lines. So when the user types `.` hoping to repeat some surrounds, "nothing" will happen, but it will stack on the undotree. I'm not sure about a workaround for this. I've thought of performing the action in an embedded headless nvim instance and taking back the result and changing the region to the updated text, but it seems overkill.