### PR TITLE
fix: Mark fields in user_option and user_surround as optional

### DIFF
--- a/lua/nvim-surround/annotations.lua
+++ b/lua/nvim-surround/annotations.lua
@@ -48,15 +48,15 @@
 ---@alias user_change false|{ target: user_delete, replacement: user_add|nil }
 
 ---@class user_surround
----@field add user_add
----@field find user_find
----@field delete user_delete
----@field change user_change
+---@field add? user_add
+---@field find? user_find
+---@field delete? user_delete
+---@field change? user_change
 
 ---@class user_options
----@field keymaps table<string, false|string>
----@field surrounds table<string, false|user_surround>
----@field aliases table<string, false|string|string[]>
----@field highlight { duration: false|integer }
----@field move_cursor false|"begin"|"end"
----@field indent_lines false|function
+---@field keymaps? table<string, false|string>
+---@field surrounds? table<string, false|user_surround>
+---@field aliases? table<string, false|string|string[]>
+---@field highlight? { duration: false|integer }
+---@field move_cursor? false|"begin"|"end"
+---@field indent_lines? false|function


### PR DESCRIPTION
Type linter complains that missing options should be valid in configuration, when in fact they're optional. This marks the fields as optional.