### PR TITLE
fix: replace deprecated `vim.tbl_islist` by native Lua function

### DIFF
--- a/lua/nvim-surround/functional.lua
+++ b/lua/nvim-surround/functional.lua
@@ -5,7 +5,7 @@ local M = {}
 ---@param t T|T[]|nil The input element.
 ---@return T[]|nil @The input wrapped in a list, if necessary.
 M.to_list = function(t)
-    if not t or vim.tbl_islist(t) then
+    if not t or type(t) == 'table' then
         return t
     end
     return { t }

--- a/lua/nvim-surround/functional.lua
+++ b/lua/nvim-surround/functional.lua
@@ -5,7 +5,7 @@ local M = {}
 ---@param t T|T[]|nil The input element.
 ---@return T[]|nil @The input wrapped in a list, if necessary.
 M.to_list = function(t)
-    if not t or type(t) == 'table' then
+    if not t or type(t) == "table" then
         return t
     end
     return { t }


### PR DESCRIPTION
This is also arguably more correct, since the previous version would also wrap non-list tables like `{ 1 = 'a', 3 = 'b' }`.

Fixes #321