### PR TITLE
Don't translate termcodes twice on input

### DIFF
--- a/lua/nvim-surround/input.lua
+++ b/lua/nvim-surround/input.lua
@@ -9,8 +9,7 @@ M.get_char = function()
     if not ok or char == "\27" then
         return nil
     end
-    -- Call this function, because config.translate_opts() does too
-    return vim.api.nvim_replace_termcodes(char, true, true, true)
+    return char
 end
 
 -- Gets a string input from the user.

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -54,6 +54,44 @@ describe("configuration", function()
         })
     end)
 
+    it("can define and use multi-byte mappings", function()
+        require("nvim-surround").setup({
+            surrounds = {
+                -- multi-byte quote
+                ["’"] = {
+                    add = { "’", "’" },
+                    delete = "^(’)().-(’)()$",
+                },
+            },
+        })
+        set_lines({ "hey! hello world" })
+        set_curpos({ 1, 7 })
+        vim.cmd("normal ysiw’")
+        check_lines({ "hey! ’hello’ world" })
+        vim.cmd("normal ds’")
+        check_lines({ "hey! hello world" })
+    end)
+
+    it("can define and use 'interpreted' multi-byte mappings", function()
+        require("nvim-surround").setup({
+            surrounds = {
+                -- interpreted multi-byte
+                ["<M-]>"] = {
+                    add = { "[[", "]]" },
+                    find = "%[%b[]%]",
+                    delete = "^(%[%[)().-(%]%])()$",
+                },
+            },
+        })
+        local meta_close_bracket = vim.api.nvim_replace_termcodes("<M-]>", true, false, true)
+        set_lines({ "hey! hello world" })
+        set_curpos({ 1, 7 })
+        vim.cmd("normal ysiw" .. meta_close_bracket)
+        check_lines({ "hey! [[hello]] world" })
+        vim.cmd("normal ds" .. meta_close_bracket)
+        check_lines({ "hey! hello world" })
+    end)
+
     it("can disable surrounds", function()
         require("nvim-surround").setup({
             surrounds = {


### PR DESCRIPTION
`getcharstr()` already returns raw internal termcodes, it is wrong to call nvim_replace_termcodes on its result.

This effectively reverts PR #273

refs: neovim/neovim#29034
fixes #325

---
The original PR #273 was supposedly fixing the issue #271, @Mango0x45 could you check if you now get that problem back or if #318 was the actual correct fix ?