### PR TITLE
fix: Default delete should work if `find` key is sane.

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -206,6 +206,9 @@ M.default_opts = {
             },
         },
         invalid_key_behavior = {
+            -- By default, we ignore control characters for adding/finding because they are more likely typos than
+            -- intentional. We choose NOT to for deletion, as users could have redefined the find key to something like
+            -- ‘.-’. In this case we should still trim a character from each side, instead of early returning nil.
             add = function(char)
                 if not char or char:find("%c") then
                     return nil
@@ -221,7 +224,7 @@ M.default_opts = {
                 })
             end,
             delete = function(char)
-                if not char or char:find("%c") then
+                if not char then
                     return nil
                 end
                 return M.get_selections({

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -92,6 +92,25 @@ describe("configuration", function()
         check_lines({ "hey! hello world" })
     end)
 
+    it("default deletes using invalid_key_behavior for an 'interpreted' multi-byte mapping", function()
+        require("nvim-surround").setup({
+            surrounds = {
+                -- interpreted multi-byte
+                ["<C-q>"] = {
+                    add = { "‘", "’" },
+                    find = "‘.-’",
+                },
+            },
+        })
+        local ctrl_q = vim.api.nvim_replace_termcodes("<C-q>", true, false, true)
+        set_lines({ "hey! hello world" })
+        set_curpos({ 1, 7 })
+        vim.cmd("normal ysiw" .. ctrl_q)
+        check_lines({ "hey! ‘hello’ world" })
+        vim.cmd("normal ds" .. ctrl_q)
+        check_lines({ "hey! hello world" })
+    end)
+
     it("can disable surrounds", function()
         require("nvim-surround").setup({
             surrounds = {


### PR DESCRIPTION
If the user has redefined `find = "‘.-’"`, then it makes more sense for default `delete` to honor that and trim quotes, rather than fail and do nothing.