### PR TITLE
feat: Improve `move_cursor`.

### DIFF
--- a/doc/nvim-surround.txt
+++ b/doc/nvim-surround.txt
@@ -613,16 +613,29 @@ configured separately. The default highlight group used is `Visual`:
 --------------------------------------------------------------------------------
 3.6. Cursor                                 *nvim-surround.config.move_cursor*
 
-By default, when a surround action is performed, the cursor moves to the
-beginning of the action.
+By default (or when `move_cursor = "begin"`), when a surround action is
+performed, the cursor moves to the beginning of the action.
 
     Old text                    Command         New text ~
     some_t*ext                  ysiw[           *[ some_text ]
     another { sample *}         ds{             another *sample
     (hello* world)              csbB            *{hello world}
 
-This behavior can be disabled by setting `move_cursor = false` in one of the
-setup functions.
+If `move_cursor` is set to `"sticky"`, the cursor will "stick" to the current
+character, and move with the text as the buffer changes.
+
+    Old text                    Command         New text ~
+    some_t*ext                  ysiw[           [ some_t*ext ]
+    another { sample *}         ds{             another sampl*e
+    (hello* world)              csbffoo<CR>     foo(hello* world)
+
+If `move_cursor` is set to `false`, the cursor won't move at all, regardless
+of how the buffer changes.
+
+    Old text                    Command         New text ~
+    some_t*ext                  ysiw[           [ some_*text ]
+    another { *sample }         ds{             another sa*mple
+    (hello* world)              csbffoo<CR>     foo(he*llo world)
 
 --------------------------------------------------------------------------------
 3.7. Indentation                           *nvim-surround.config.indent_lines*

--- a/lua/nvim-surround/annotations.lua
+++ b/lua/nvim-surround/annotations.lua
@@ -35,7 +35,7 @@
 ---@field surrounds table<string, surround>
 ---@field aliases table<string, string|string[]>
 ---@field highlight { duration: integer }
----@field move_cursor false|"begin"|"end"
+---@field move_cursor false|"begin"|"end"|"sticky"
 ---@field indent_lines function
 
 --[====================================================================================================================[

--- a/lua/nvim-surround/annotations.lua
+++ b/lua/nvim-surround/annotations.lua
@@ -35,7 +35,7 @@
 ---@field surrounds table<string, surround>
 ---@field aliases table<string, string|string[]>
 ---@field highlight { duration: integer }
----@field move_cursor false|"begin"|"end"|"sticky"
+---@field move_cursor false|"begin"|"sticky"
 ---@field indent_lines function
 
 --[====================================================================================================================[
@@ -58,5 +58,5 @@
 ---@field surrounds? table<string, false|user_surround>
 ---@field aliases? table<string, false|string|string[]>
 ---@field highlight? { duration: false|integer }
----@field move_cursor? false|"begin"|"end"
+---@field move_cursor? false|"begin"|"sticky"
 ---@field indent_lines? false|function

--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -23,12 +23,49 @@ M.set_curpos = function(pos)
     vim.api.nvim_win_set_cursor(0, { pos[1], pos[2] - 1 })
 end
 
+-- Get notable cursor positions from a selection, taking delimiters into account.
+---@param cur_pos position The original cursor position.
+---@param selection selection The selection to get positions from.
+---@param delimiters string[][] The delimiters to get positions from.
+---@return { first_pos: position, last_pos: position, sticky_pos: position }
+---@nodiscard
+M.get_curpos_from_selection = function(cur_pos, selection, delimiters)
+    -- The cursor column depends on the delimiter length
+    local last_pos = vim.deepcopy(selection.last_pos)
+    last_pos[1] = last_pos[1] + #delimiters[1] + #delimiters[2] - 2
+    if #delimiters[1] == 1 then
+        last_pos[2] = last_pos[2] + #delimiters[1][#delimiters[1]]
+    else
+        last_pos[2] = #delimiters[1][#delimiters[1]]
+    end
+    if #delimiters[2] == 1 then
+        last_pos[2] = last_pos[2] + #delimiters[2][#delimiters[2]]
+    else
+        last_pos[2] = #delimiters[2][#delimiters[2]]
+    end
+
+    local sticky_pos = vim.deepcopy(cur_pos)
+    sticky_pos[1] = sticky_pos[1] + #delimiters[1] - 1
+    if #delimiters[1] == 1 then
+        sticky_pos[2] = sticky_pos[2] + #delimiters[1][#delimiters[1]]
+    end
+
+    return {
+        first_pos = vim.deepcopy(selection.first_pos),
+        last_pos = last_pos,
+        sticky_pos = sticky_pos,
+    }
+end
+
 -- Move the cursor to a location in the buffer, depending on the `move_cursor` setting.
----@param pos { first_pos: position, old_pos: position } Various positions in the buffer.
+---@param pos { first_pos: position, last_pos: position, sticky_pos: position, old_pos: position } Various positions in the buffer.
 M.restore_curpos = function(pos)
-    -- TODO: Add a `last_pos` field for if `move_cursor` is set to "end"
     if config.get_opts().move_cursor == "begin" then
         M.set_curpos(pos.first_pos)
+    -- elseif config.get_opts().move_cursor == "end" then
+    --     M.set_curpos(pos.last_pos)
+    -- elseif config.get_opts().move_cursor == "sticky" then
+    --     M.set_curpos(pos.sticky_pos)
     elseif not config.get_opts().move_cursor then
         M.set_curpos(pos.old_pos)
     end

--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -24,13 +24,13 @@ M.set_curpos = function(pos)
 end
 
 -- Move the cursor to a location in the buffer, depending on the `move_cursor` setting.
----@param pos { first_pos: position, last_pos: position, sticky_pos: position, old_pos: position } Various positions in the buffer.
+---@param pos { first_pos: position, sticky_pos: position, old_pos: position } Various positions in the buffer.
 M.restore_curpos = function(pos)
     if config.get_opts().move_cursor == "begin" then
         M.set_curpos(pos.first_pos)
     elseif config.get_opts().move_cursor == "sticky" then
         M.set_curpos(pos.sticky_pos)
-    elseif config.get_opts().move_cursor then
+    elseif not config.get_opts().move_cursor then
         M.set_curpos(pos.old_pos)
     end
 end

--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -140,6 +140,12 @@ M.set_extmark = function(pos)
     return vim.api.nvim_buf_set_extmark(0, M.namespace.extmark, pos[1] - 1, pos[2] - 1, {})
 end
 
+-- Deletes an extmark from the buffer.
+---@param extmark integer The extmark ID number.
+M.del_extmark = function(extmark)
+    vim.api.nvim_buf_del_extmark(0, M.namespace.extmark, extmark)
+end
+
 --[====================================================================================================================[
                                              Byte indexing helper functions
 --]====================================================================================================================]

--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -2,6 +2,11 @@ local config = require("nvim-surround.config")
 
 local M = {}
 
+M.namespace = {
+    highlight = vim.api.nvim_create_namespace("nvim-surround-highlight"),
+    extmark = vim.api.nvim_create_namespace("nvim-surround-extmark"),
+}
+
 --[====================================================================================================================[
                                                 Cursor helper functions
 --]====================================================================================================================]
@@ -123,8 +128,7 @@ end
 ---@return position @The position of the extmark in the buffer.
 ---@nodiscard
 M.get_extmark = function(extmark)
-    local ns = vim.api.nvim_create_namespace("nvim-surround")
-    local pos = vim.api.nvim_buf_get_extmark_by_id(0, ns, extmark, {})
+    local pos = vim.api.nvim_buf_get_extmark_by_id(0, M.namespace.extmark, extmark, {})
     return { pos[1] + 1, pos[2] + 1 }
 end
 
@@ -133,8 +137,7 @@ end
 ---@return integer @The extmark ID.
 ---@nodiscard
 M.set_extmark = function(pos)
-    local ns = vim.api.nvim_create_namespace("nvim-surround")
-    return vim.api.nvim_buf_set_extmark(0, ns, pos[1] - 1, pos[2] - 1, {})
+    return vim.api.nvim_buf_set_extmark(0, M.namespace.extmark, pos[1] - 1, pos[2] - 1, {})
 end
 
 --[====================================================================================================================[
@@ -277,11 +280,10 @@ M.highlight_selection = function(selection)
     if not selection then
         return
     end
-    local namespace = vim.api.nvim_create_namespace("NvimSurround")
 
     vim.highlight.range(
         0,
-        namespace,
+        M.namespace.highlight,
         "NvimSurroundHighlight",
         { selection.first_pos[1] - 1, selection.first_pos[2] - 1 },
         { selection.last_pos[1] - 1, selection.last_pos[2] - 1 },
@@ -293,8 +295,7 @@ end
 
 -- Clears all nvim-surround highlights for the buffer.
 M.clear_highlights = function()
-    local namespace = vim.api.nvim_create_namespace("NvimSurround")
-    vim.api.nvim_buf_clear_namespace(0, namespace, 0, -1)
+    vim.api.nvim_buf_clear_namespace(0, M.namespace.highlight, 0, -1)
     -- Force the screen to clear the highlight immediately
     vim.cmd.redraw()
 end

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -64,13 +64,13 @@ M.normal_surround = function(args)
     local first_pos = args.selection.first_pos
     local last_pos = { args.selection.last_pos[1], args.selection.last_pos[2] + 1 }
 
+    local sticky_mark = buffer.set_extmark(M.normal_curpos)
     buffer.insert_text(last_pos, args.delimiters[2])
     buffer.insert_text(first_pos, args.delimiters[1])
-    local positions = buffer.get_curpos_from_selection(M.normal_curpos, args.selection, args.delimiters)
+
     buffer.restore_curpos({
-        first_pos = positions.first_pos,
-        last_pos = positions.last_pos,
-        sticky_pos = positions.sticky_pos,
+        first_pos = first_pos,
+        sticky_pos = buffer.get_extmark(sticky_mark),
         old_pos = M.normal_curpos,
     })
 
@@ -146,8 +146,11 @@ M.visual_surround = function(args)
 
     config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
 
-    local positions =
-        buffer.get_curpos_from_selection(M.normal_curpos, { first_pos = first_pos, last_pos = last_pos }, delimiters)
+    local positions = buffer.get_last_pos_after_adding_delimiters(
+        M.normal_curpos,
+        { first_pos = first_pos, last_pos = last_pos },
+        delimiters
+    )
     buffer.restore_curpos({
         first_pos = positions.first_pos,
         last_pos = positions.last_pos,

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -95,6 +95,7 @@ M.visual_surround = function(args)
         return
     end
 
+    local sticky_mark = buffer.set_extmark(args.curpos)
     if vim.fn.visualmode() == "\22" then -- Visual block mode case (add delimiters to every line)
         if vim.o.selection == "exclusive" then
             last_pos[2] = last_pos[2] - 1
@@ -144,13 +145,12 @@ M.visual_surround = function(args)
         buffer.insert_text(first_pos, delimiters[1])
     end
 
-    config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
-
-    -- TODO: We should be updating the cursor after every insertion, in case the cursor is sticky.
     buffer.restore_curpos({
         first_pos = first_pos,
+        sticky_pos = buffer.get_extmark(sticky_mark),
         old_pos = args.curpos,
     })
+    config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
 end
 
 -- Delete a surrounding delimiter pair, if it exists.

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -145,8 +145,13 @@ M.visual_surround = function(args)
     end
 
     config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
+
+    local positions =
+        buffer.get_curpos_from_selection(M.normal_curpos, { first_pos = first_pos, last_pos = last_pos }, delimiters)
     buffer.restore_curpos({
-        first_pos = first_pos,
+        first_pos = positions.first_pos,
+        last_pos = positions.last_pos,
+        sticky_pos = positions.sticky_pos,
         old_pos = args.curpos,
     })
 end
@@ -175,6 +180,13 @@ M.delete_surround = function(args)
             selections.left.first_pos[1],
             selections.left.first_pos[1] + selections.right.first_pos[1] - selections.left.last_pos[1]
         )
+        -- TODO: Figure out deletion
+        -- buffer.restore_curpos({
+        --     first_pos = selections.left.first_pos,
+        --     last_pos = selections.right.first_pos,
+        --     sticky_pos = nil,
+        --     old_pos = args.curpos,
+        -- })
         buffer.restore_curpos({
             first_pos = selections.left.first_pos,
             old_pos = args.curpos,

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -73,6 +73,7 @@ M.normal_surround = function(args)
         sticky_pos = buffer.get_extmark(sticky_mark),
         old_pos = M.normal_curpos,
     })
+    buffer.del_extmark(sticky_mark)
 
     if args.line_mode then
         config.get_opts().indent_lines(first_pos[1], last_pos[1] + #args.delimiters[1] + #args.delimiters[2] - 2)
@@ -145,12 +146,13 @@ M.visual_surround = function(args)
         buffer.insert_text(first_pos, delimiters[1])
     end
 
+    config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
     buffer.restore_curpos({
         first_pos = first_pos,
         sticky_pos = buffer.get_extmark(sticky_mark),
         old_pos = args.curpos,
     })
-    config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
+    buffer.del_extmark(sticky_mark)
 end
 
 -- Delete a surrounding delimiter pair, if it exists.
@@ -184,6 +186,7 @@ M.delete_surround = function(args)
             sticky_pos = buffer.get_extmark(sticky_mark),
             old_pos = args.curpos,
         })
+        buffer.del_extmark(sticky_mark)
     end
 
     cache.set_callback("v:lua.require'nvim-surround'.delete_callback")
@@ -238,6 +241,7 @@ M.change_surround = function(args)
             sticky_pos = buffer.get_extmark(sticky_mark),
             old_pos = args.curpos,
         })
+        buffer.del_extmark(sticky_mark)
 
         if args.line_mode then
             local first_pos = selections.left.first_pos

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -170,22 +170,18 @@ M.delete_surround = function(args)
     local selections = utils.get_nearest_selections(args.del_char, "delete")
 
     if selections then
+        local sticky_mark = buffer.set_extmark(args.curpos)
         -- Delete the right selection first to ensure selection positions are correct
         buffer.delete_selection(selections.right)
         buffer.delete_selection(selections.left)
+
         config.get_opts().indent_lines(
             selections.left.first_pos[1],
             selections.left.first_pos[1] + selections.right.first_pos[1] - selections.left.last_pos[1]
         )
-        -- TODO: Figure out deletion
-        -- buffer.restore_curpos({
-        --     first_pos = selections.left.first_pos,
-        --     last_pos = selections.right.first_pos,
-        --     sticky_pos = nil,
-        --     old_pos = args.curpos,
-        -- })
         buffer.restore_curpos({
             first_pos = selections.left.first_pos,
+            sticky_pos = buffer.get_extmark(sticky_mark),
             old_pos = args.curpos,
         })
     end
@@ -233,11 +229,13 @@ M.change_surround = function(args)
             selections.right.first_pos[2] = space_end + 1
         end
 
+        local sticky_mark = buffer.set_extmark(args.curpos)
         -- Change the right selection first to ensure selection positions are correct
         buffer.change_selection(selections.right, delimiters[2])
         buffer.change_selection(selections.left, delimiters[1])
         buffer.restore_curpos({
             first_pos = selections.left.first_pos,
+            sticky_pos = buffer.get_extmark(sticky_mark),
             old_pos = args.curpos,
         })
 

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -66,8 +66,11 @@ M.normal_surround = function(args)
 
     buffer.insert_text(last_pos, args.delimiters[2])
     buffer.insert_text(first_pos, args.delimiters[1])
+    local positions = buffer.get_curpos_from_selection(M.normal_curpos, args.selection, args.delimiters)
     buffer.restore_curpos({
-        first_pos = first_pos,
+        first_pos = positions.first_pos,
+        last_pos = positions.last_pos,
+        sticky_pos = positions.sticky_pos,
         old_pos = M.normal_curpos,
     })
 

--- a/lua/nvim-surround/init.lua
+++ b/lua/nvim-surround/init.lua
@@ -146,15 +146,9 @@ M.visual_surround = function(args)
 
     config.get_opts().indent_lines(first_pos[1], last_pos[1] + #delimiters[1] + #delimiters[2] - 2)
 
-    local positions = buffer.get_last_pos_after_adding_delimiters(
-        M.normal_curpos,
-        { first_pos = first_pos, last_pos = last_pos },
-        delimiters
-    )
+    -- TODO: We should be updating the cursor after every insertion, in case the cursor is sticky.
     buffer.restore_curpos({
-        first_pos = positions.first_pos,
-        last_pos = positions.last_pos,
-        sticky_pos = positions.sticky_pos,
+        first_pos = first_pos,
         old_pos = args.curpos,
     })
 end

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -1,5 +1,6 @@
 local cr = vim.api.nvim_replace_termcodes("<CR>", true, false, true)
 local esc = vim.api.nvim_replace_termcodes("<Esc>", true, false, true)
+local ctrl_v = vim.api.nvim_replace_termcodes("<C-v>", true, false, true)
 local get_curpos = function()
     local curpos = vim.api.nvim_win_get_cursor(0)
     return { curpos[1], curpos[2] + 1 }
@@ -323,6 +324,86 @@ describe("configuration", function()
         vim.cmd("normal ysa'e")
         vim.cmd("normal ysa'f")
         check_curpos({ 1, 2 })
+    end)
+
+    it("can make the cursor 'stick' to the text (visual)", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "sticky",
+        })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal vllS'")
+        check_curpos({ 1, 12 })
+
+        set_lines({
+            "this is a line",
+            "with some more text",
+        })
+        set_curpos({ 1, 6 })
+        vim.cmd("normal vjeSb")
+        check_curpos({ 2, 9 })
+
+        set_lines({
+            "this is a line",
+            "with some more text",
+        })
+        set_curpos({ 1, 6 })
+        vim.cmd("normal vjeoSb")
+        check_curpos({ 1, 7 })
+    end)
+
+    it("can make the cursor 'stick' to the text (visual line)", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "sticky",
+        })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal VSb")
+        check_curpos({ 2, 9 })
+
+        set_lines({
+            "this is a line",
+            "with some more text",
+        })
+        set_curpos({ 1, 6 })
+        vim.cmd("normal VjStdiv" .. cr)
+        check_curpos({ 3, 6 })
+    end)
+
+    it("can make the cursor 'stick' to the text (visual block)", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "sticky",
+            surrounds = {
+                ["x"] = {
+                    add = { { "|", "" }, { "", "|" } },
+                },
+            },
+        })
+
+        set_lines({
+            "this is a line",
+            "this is another line",
+        })
+        set_curpos({ 1, 5 })
+        vim.cmd("normal! " .. ctrl_v .. "jf ")
+        vim.cmd("normal Sb")
+        check_curpos({ 2, 9 })
+
+        set_lines({
+            "this is a line",
+            "this is another line",
+            "some more random text",
+        })
+        set_curpos({ 1, 4 })
+        vim.cmd("normal! " .. ctrl_v .. "jjww")
+        vim.cmd("normal Sx")
+        set_curpos({ 8, 8 })
     end)
 
     it("can make the cursor 'stick' to the text (delete)", function()

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -323,14 +323,6 @@ describe("configuration", function()
         vim.cmd("normal ysa'e")
         vim.cmd("normal ysa'f")
         check_curpos({ 1, 2 })
-
-        -- Sticks to the text if the cursor comes after the selection
-        set_lines({
-            "this 'is' a line",
-        })
-        set_curpos({ 1, 13 })
-        vim.cmd("normal ysa'b")
-        check_curpos({ 1, 15 })
     end)
 
     it("can make the cursor 'stick' to the text (delete)", function() end)

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -325,7 +325,46 @@ describe("configuration", function()
         check_curpos({ 1, 2 })
     end)
 
-    it("can make the cursor 'stick' to the text (delete)", function() end)
+    it("can make the cursor 'stick' to the text (delete)", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "sticky",
+            surrounds = {
+                ["c"] = { add = { "singleline", "surr" } },
+                ["d"] = { add = { { "multiline", "f" }, "" } },
+                ["e"] = { add = { { "multiline", "f" }, { "", "shouldbethislength" } } },
+            },
+        })
+
+        set_lines({
+            "func_name(foobar)",
+        })
+        set_curpos({ 1, 14 })
+        vim.cmd("normal dsf")
+        check_curpos({ 1, 4 })
+
+        set_lines({
+            "<div id='foobar'>",
+            "    hello",
+            "</div>",
+        })
+        set_curpos({ 2, 7 })
+        vim.cmd("normal dst")
+        check_curpos({ 2, 7 })
+
+        set_lines({
+            "hello 'world'",
+        })
+        set_curpos({ 1, 2 })
+        vim.cmd("normal dsq")
+        check_curpos({ 1, 2 })
+
+        set_lines({
+            "func(hello) world",
+        })
+        set_curpos({ 1, 14 })
+        vim.cmd("normal dsf")
+        check_curpos({ 1, 8 })
+    end)
 
     it("can partially define surrounds", function()
         require("nvim-surround").buffer_setup({

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -278,6 +278,9 @@ describe("configuration", function()
             move_cursor = "end",
             surrounds = {
                 ["c"] = { add = { "singleline", "surr" } },
+                ["d"] = { add = { { "multiline", "f" }, "" } },
+                ["e"] = { add = { { "multiline", "f" }, { "", "shouldbethislength" } } },
+                ["f"] = { add = { "singleline", { "", "multilinehere" } } },
             },
         })
 
@@ -287,6 +290,79 @@ describe("configuration", function()
         set_curpos({ 1, 9 })
         vim.cmd("normal ysiwc")
         check_curpos({ 1, 23 })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal ysiwd")
+        check_curpos({ 2, 1 })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal ysiwe")
+        check_curpos({ 3, 18 })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal ysiwf")
+        check_curpos({ 2, 13 })
+    end)
+
+    it("can make the cursor 'stick' to the text", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "sticky",
+            surrounds = {
+                ["c"] = { add = { "singleline", "surr" } },
+                ["d"] = { add = { { "multiline", "f" }, "" } },
+                ["e"] = { add = { { "multiline", "f" }, { "", "shouldbethislength" } } },
+                ["f"] = { add = { "singleline", { "", "multilinehere" } } },
+            },
+        })
+
+        -- Sticks to the text if the cursor is inside the selection
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal ysiwc")
+        check_curpos({ 1, 19 })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 4 })
+        vim.cmd("normal ysiwd")
+        check_curpos({ 2, 5 })
+
+        set_lines({
+            "this is another line",
+        })
+        set_curpos({ 1, 14 })
+        vim.cmd("normal ysiwe")
+        check_curpos({ 2, 7 })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal ysiwf")
+        check_curpos({ 1, 19 })
+
+        -- Doesn't move if the cursor is before the selection
+        set_lines({
+            "this 'is' a line",
+        })
+        set_curpos({ 1, 2 })
+        vim.cmd("normal ysa'c")
+        vim.cmd("normal ysa'd")
+        vim.cmd("normal ysa'e")
+        vim.cmd("normal ysa'f")
+        check_curpos({ 1, 2 })
     end)
 
     it("can partially define surrounds", function()

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -328,11 +328,6 @@ describe("configuration", function()
     it("can make the cursor 'stick' to the text (delete)", function()
         require("nvim-surround").buffer_setup({
             move_cursor = "sticky",
-            surrounds = {
-                ["c"] = { add = { "singleline", "surr" } },
-                ["d"] = { add = { { "multiline", "f" }, "" } },
-                ["e"] = { add = { { "multiline", "f" }, { "", "shouldbethislength" } } },
-            },
         })
 
         set_lines({
@@ -364,6 +359,44 @@ describe("configuration", function()
         set_curpos({ 1, 14 })
         vim.cmd("normal dsf")
         check_curpos({ 1, 8 })
+    end)
+
+    it("can make the cursor 'stick' to the text (change)", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "sticky",
+        })
+
+        set_lines({
+            "func_name(foobar)",
+        })
+        set_curpos({ 1, 14 })
+        vim.cmd("normal csff" .. cr)
+        check_curpos({ 1, 6 })
+
+        set_lines({
+            "<div id='foobar'>",
+            "    hello",
+            "</div>",
+        })
+        set_curpos({ 2, 7 })
+        vim.cmd("normal csth1" .. cr)
+        check_curpos({ 2, 7 })
+        vim.cmd("normal csTbutton" .. cr)
+        check_curpos({ 2, 7 })
+
+        set_lines({
+            "hello 'world'",
+        })
+        set_curpos({ 1, 2 })
+        vim.cmd("normal csqffoobar" .. cr)
+        check_curpos({ 1, 2 })
+
+        set_lines({
+            "<div className='container'>hello</div> world",
+        })
+        set_curpos({ 1, 41 })
+        vim.cmd("normal csTb" .. cr)
+        check_curpos({ 1, 15 })
     end)
 
     it("can partially define surrounds", function()

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -273,47 +273,7 @@ describe("configuration", function()
         })
     end)
 
-    it("can move the cursor to the end of an action", function()
-        require("nvim-surround").buffer_setup({
-            move_cursor = "end",
-            surrounds = {
-                ["c"] = { add = { "singleline", "surr" } },
-                ["d"] = { add = { { "multiline", "f" }, "" } },
-                ["e"] = { add = { { "multiline", "f" }, { "", "shouldbethislength" } } },
-                ["f"] = { add = { "singleline", { "", "multilinehere" } } },
-            },
-        })
-
-        set_lines({
-            "this is a line",
-        })
-        set_curpos({ 1, 9 })
-        vim.cmd("normal ysiwc")
-        check_curpos({ 1, 23 })
-
-        set_lines({
-            "this is a line",
-        })
-        set_curpos({ 1, 9 })
-        vim.cmd("normal ysiwd")
-        check_curpos({ 2, 1 })
-
-        set_lines({
-            "this is a line",
-        })
-        set_curpos({ 1, 9 })
-        vim.cmd("normal ysiwe")
-        check_curpos({ 3, 18 })
-
-        set_lines({
-            "this is a line",
-        })
-        set_curpos({ 1, 9 })
-        vim.cmd("normal ysiwf")
-        check_curpos({ 2, 13 })
-    end)
-
-    it("can make the cursor 'stick' to the text", function()
+    it("can make the cursor 'stick' to the text (normal)", function()
         require("nvim-surround").buffer_setup({
             move_cursor = "sticky",
             surrounds = {
@@ -363,7 +323,17 @@ describe("configuration", function()
         vim.cmd("normal ysa'e")
         vim.cmd("normal ysa'f")
         check_curpos({ 1, 2 })
+
+        -- Sticks to the text if the cursor comes after the selection
+        set_lines({
+            "this 'is' a line",
+        })
+        set_curpos({ 1, 13 })
+        vim.cmd("normal ysa'b")
+        check_curpos({ 1, 15 })
     end)
+
+    it("can make the cursor 'stick' to the text (delete)", function() end)
 
     it("can partially define surrounds", function()
         require("nvim-surround").buffer_setup({

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -17,6 +17,9 @@ end
 local check_lines = function(lines)
     assert.are.same(lines, vim.api.nvim_buf_get_lines(0, 0, -1, false))
 end
+local get_extmarks = function()
+    return vim.api.nvim_buf_get_extmarks(0, require("nvim-surround.buffer").namespace.extmark, 0, -1, {})
+end
 
 describe("configuration", function()
     before_each(function()
@@ -324,6 +327,8 @@ describe("configuration", function()
         vim.cmd("normal ysa'e")
         vim.cmd("normal ysa'f")
         check_curpos({ 1, 2 })
+
+        assert.are.same(get_extmarks(), {})
     end)
 
     it("can make the cursor 'stick' to the text (visual)", function()
@@ -353,6 +358,8 @@ describe("configuration", function()
         set_curpos({ 1, 6 })
         vim.cmd("normal vjeoSb")
         check_curpos({ 1, 7 })
+
+        assert.are.same(get_extmarks(), {})
     end)
 
     it("can make the cursor 'stick' to the text (visual line)", function()
@@ -374,6 +381,8 @@ describe("configuration", function()
         set_curpos({ 1, 6 })
         vim.cmd("normal VjStdiv" .. cr)
         check_curpos({ 3, 6 })
+
+        assert.are.same(get_extmarks(), {})
     end)
 
     it("can make the cursor 'stick' to the text (visual block)", function()
@@ -404,6 +413,8 @@ describe("configuration", function()
         vim.cmd("normal! " .. ctrl_v .. "jjww")
         vim.cmd("normal Sx")
         set_curpos({ 8, 8 })
+
+        assert.are.same(get_extmarks(), {})
     end)
 
     it("can make the cursor 'stick' to the text (delete)", function()
@@ -440,6 +451,8 @@ describe("configuration", function()
         set_curpos({ 1, 14 })
         vim.cmd("normal dsf")
         check_curpos({ 1, 8 })
+
+        assert.are.same(get_extmarks(), {})
     end)
 
     it("can make the cursor 'stick' to the text (change)", function()
@@ -478,6 +491,8 @@ describe("configuration", function()
         set_curpos({ 1, 41 })
         vim.cmd("normal csTb" .. cr)
         check_curpos({ 1, 15 })
+
+        assert.are.same(get_extmarks(), {})
     end)
 
     it("can partially define surrounds", function()

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -7,6 +7,9 @@ end
 local set_curpos = function(pos)
     vim.api.nvim_win_set_cursor(0, { pos[1], pos[2] - 1 })
 end
+local check_curpos = function(pos)
+    assert.are.same({ pos[1], pos[2] - 1 }, vim.api.nvim_win_get_cursor(0))
+end
 local set_lines = function(lines)
     vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
 end
@@ -21,7 +24,7 @@ describe("configuration", function()
     end)
 
     it("can define own add mappings", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             surrounds = {
                 ["1"] = { add = { "1", "1" } },
                 ["2"] = { add = { "2", { "2" } } },
@@ -75,7 +78,7 @@ describe("configuration", function()
     end)
 
     it("can define and use 'interpreted' multi-byte mappings", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             surrounds = {
                 -- interpreted multi-byte
                 ["<M-]>"] = {
@@ -95,7 +98,7 @@ describe("configuration", function()
     end)
 
     it("default deletes using invalid_key_behavior for an 'interpreted' multi-byte mapping", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             surrounds = {
                 -- interpreted multi-byte
                 ["<C-q>"] = {
@@ -114,7 +117,7 @@ describe("configuration", function()
     end)
 
     it("can disable surrounds", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             surrounds = {
                 ["("] = false,
             },
@@ -130,7 +133,7 @@ describe("configuration", function()
     end)
 
     it("can change invalid_key_behavior", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             surrounds = {
                 invalid_key_behavior = {
                     add = function(char)
@@ -150,7 +153,7 @@ describe("configuration", function()
     end)
 
     it("can disable indent_lines", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             indent_lines = false,
         })
 
@@ -166,7 +169,7 @@ describe("configuration", function()
     end)
 
     it("can disable invalid_key_behavior", function()
-        require("nvim-surround").setup({
+        require("nvim-surround").buffer_setup({
             surrounds = {
                 invalid_key_behavior = false,
             },
@@ -268,6 +271,22 @@ describe("configuration", function()
         check_lines({
             [[And jump ("forwards and backwards" to the nearest) surround.]],
         })
+    end)
+
+    it("can move the cursor to the end of an action", function()
+        require("nvim-surround").buffer_setup({
+            move_cursor = "end",
+            surrounds = {
+                ["c"] = { add = { "singleline", "surr" } },
+            },
+        })
+
+        set_lines({
+            "this is a line",
+        })
+        set_curpos({ 1, 9 })
+        vim.cmd("normal ysiwc")
+        check_curpos({ 1, 23 })
     end)
 
     it("can partially define surrounds", function()


### PR DESCRIPTION
This aims to add a "sticky" option for `move_cursor`, where "sticky" keeps the cursor "stuck" to whatever character the cursor was on before the surround action. See the unit tests in this PR for an idea of how exactly this would work.

One nice use case for this is dot-repeating with a sticky cursor, as one can do `ysiw].` to surround a word with double brackets, whereas the old behavior would do something like `hello` &rarr; `[[]hello]` (since the dot-repeat would surround the open square bracket).

Please react to show interest in this feature!

Replaces #289; is a partial solution to #281

## TODO

- [x] Unit test inserting where the selection is entirely before the cursor.
- [x] Make it work for deletion/changing.
- [x] Document the new functionality.