### PR TITLE
fix: Attempt to unblock `luarocks-release`.

### DIFF
--- a/.github/workflows/luarocks-release.yml
+++ b/.github/workflows/luarocks-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "*"
+  release:
+    types:
+      - created
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
-          release-type: node
-          package-name: release-please-action
+          release-type: simple
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Using a GitHub private access token in order to allow other actions to run on top of the `release-please` action, since otherwise they are blocked to avoid recursive actions.

> You will want to configure a GitHub Actions secret with a Personal Access Token
> if you want GitHub Actions CI checks to run on Release Please PRs.

Ref: https://github.com/googleapis/release-please-action?tab=readme-ov-file#other-actions-on-release-please-prs