### PR TITLE
fix: use `vim.hl` if available

### DIFF
--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -303,7 +303,10 @@ M.highlight_selection = function(selection)
         return
     end
 
-    vim.highlight.range(
+    -- Use the non-deprecated module if available.
+    local highlight = vim.hl or vim.highlight
+
+    highlight.range(
         0,
         M.namespace.highlight,
         "NvimSurroundHighlight",


### PR DESCRIPTION
The module was renamed in https://github.com/neovim/neovim/pull/30840, and in newer Neovim versions `vim.highlight` is deprecated.