### PR TITLE
fix(treesitter): simpler root node calculation

### DIFF
--- a/lua/nvim-surround/treesitter.lua
+++ b/lua/nvim-surround/treesitter.lua
@@ -37,15 +37,7 @@ end
 ---@nodiscard
 M.get_root = function()
     local node = get_node()
-    if node == nil then
-        return nil
-    end
-
-    while node:parent() ~= nil do
-        node = node:parent()
-    end
-
-    return node
+    return node and node:tree():root()
 end
 
 -- Gets the current smallest node at the cursor.


### PR DESCRIPTION
This eliminates the need to traverse up the tree to find its root, which can be costly for deep trees.