### PR TITLE
fix: `index_to_pos` on Windows machines.

### DIFF
--- a/tests/basics_spec.lua
+++ b/tests/basics_spec.lua
@@ -904,4 +904,23 @@ describe("nvim-surround", function()
         vim.cmd("normal 3csbr")
         check_lines({ "some [[more placeholder]] text" })
     end)
+
+    it("can perform operations on Windows", function()
+        vim.bo.fileformat = "dos"
+        set_lines({
+            "(removing these parenthesis works)",
+            "{",
+            "(removing these parenthesis creates behaves weirdly and changes characters)",
+            "}",
+        })
+        set_curpos({ 1, 1 })
+        vim.cmd("normal dsbjjds)")
+
+        check_lines({
+            "removing these parenthesis works",
+            "{",
+            "removing these parenthesis creates behaves weirdly and changes characters",
+            "}",
+        })
+    end)
 end)


### PR DESCRIPTION
The APIs used in converting 1D and 2D indices are asymmetric in that one of them assumes EOL is 1 byte, and the other uses the EOL provided by the current buffer's `fileformat`.
Should resolve #400.