### PR TITLE
fix: Adding/changing surrounds should highlight, even without invoking `setup`.

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -595,18 +595,6 @@ M.setup = function(user_opts)
     end
     -- Overwrite default options with user-defined options, if they exist
     M.user_opts = M.merge_opts(M.translate_opts(M.default_opts), user_opts)
-    -- Configure highlight group, if necessary
-    if M.user_opts.highlight.duration then
-        vim.cmd.highlight("default link NvimSurroundHighlight Visual")
-    end
-    -- Intercept dot repeat action, remembering cursor position
-    local buffer = require("nvim-surround.buffer")
-    local nvim_surround = require("nvim-surround")
-    vim.on_key(function(key)
-        if key == "." and not nvim_surround.pending_surround then
-            nvim_surround.normal_curpos = buffer.get_curpos()
-        end
-    end)
 end
 
 -- Setup the user options for the current buffer.

--- a/plugin/nvim-surround.lua
+++ b/plugin/nvim-surround.lua
@@ -1,3 +1,12 @@
+-- Configure default highlight group.
+vim.cmd.highlight("default link NvimSurroundHighlight Visual")
+-- Intercept dot repeat action and save the cursor position, but only if the user is not currently completing a surround
+-- action. This is done so `move_cursor = false` works with dot-repeating.
+vim.on_key(function(key)
+    if key == "." and not require("nvim-surround").pending_surround then
+        require("nvim-surround").normal_curpos = require("nvim-surround.buffer").get_curpos()
+    end
+end)
 --[====================================================================================================================[
                                                     DEFAULT KEYMAPS
 --]====================================================================================================================]


### PR DESCRIPTION
Set the `NvimSurroundHighlight` group by default, even if `setup` is not invoked.