### PR TITLE
fix: Incorrect handling of consecutive newline visual surrounds.

### DIFF
--- a/lua/nvim-surround/config.lua
+++ b/lua/nvim-surround/config.lua
@@ -347,7 +347,7 @@ M.get_delimiters = function(char, line_mode)
     if raw_delimiters == nil then
         return nil
     end
-    local delimiters = utils.normalize_delimiters(raw_delimiters)
+    local delimiters = vim.deepcopy(utils.normalize_delimiters(raw_delimiters))
     local lhs = delimiters[1]
     local rhs = delimiters[2]
 

--- a/tests/configuration_spec.lua
+++ b/tests/configuration_spec.lua
@@ -621,4 +621,18 @@ describe("configuration", function()
         check_lines({ "[(foo) bar [baz]]" })
         check_curpos({ 1, 9 })
     end)
+
+    it("handles consecutive surrounds on new lines", function()
+        require("nvim-surround").setup({
+            move_cursor = "sticky",
+            surrounds = {
+                d = {
+                    add = { { "foo" }, { "bar" } },
+                },
+            },
+        })
+        set_lines({ "foobarbaz" })
+        vim.cmd("normal VSdVSdVSd")
+        check_lines({ "foo", "foo", "foo", "foobarbaz", "bar", "bar", "bar" })
+    end)
 end)


### PR DESCRIPTION
When a visual surround is done with `<Plug>(nvim-surround-visual-line)`, the padding is added by prepending/appending newlines to both delimiters in the pair. However, when tables are passed around in function parameters, they are passed by object reference. This means that when we were getting delimiters from the configuration, modifying the "local copies" meant actually modifying the user configuration.

The fix here is to make a deep copy any time we are reading from the user configuration, to avoid mutating it and creating excessive padding on the delimiter pairs.

Resolves #429.