### PR TITLE
fix: Incorrect highlights when changing surrounds.

### DIFF
--- a/lua/nvim-surround/buffer.lua
+++ b/lua/nvim-surround/buffer.lua
@@ -299,7 +299,7 @@ end
 -- Highlights a given selection.
 ---@param selection selection|nil The selection to be highlighted.
 M.highlight_selection = function(selection)
-    if not selection then
+    if not selection or M.comes_before(selection.last_pos, selection.first_pos) then
         return
     end
 


### PR DESCRIPTION
It seems like highlighting a selection works even if the selected range is backwards, i.e. the provided start position comes _after_ the end position. I'm not sure if this has always been broken since I added highlighting to this plugin, or if `vim.hl` has "recently" supported highlighting "backwards" selections. In any case, we just assert that the first position comes before the last position, and no-op if that doesn't hold.

Tested this manually with a `csf` invocation, which _shouldn't_ highlight the closing parenthesis at all.